### PR TITLE
ci: setup google cloud on tags

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -81,17 +81,17 @@ jobs:
         run: make orchestrator
 
       - name: Authenticate to Google Cloud
-        if: steps.changed_migrations.outputs.any_changed == 'true'
+        if: steps.changed_migrations.outputs.any_changed == 'true' || github.ref_type == 'tag'
         uses: google-github-actions/auth@v0
         with:
           credentials_json: '${{ secrets.GCP_BUCKET_SECRET }}'
 
       - name: Set up Google Cloud CLI
-        if: steps.changed_migrations.outputs.any_changed == 'true'
+        if: steps.changed_migrations.outputs.any_changed == 'true' || github.ref_type == 'tag'
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Install psql
-        if: steps.changed_migrations.outputs.any_changed == 'true'
+        if: steps.changed_migrations.outputs.any_changed == 'true' || github.ref_type == 'tag'
         run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends postgresql-client


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
On tag publication we upload a golden snapshot of the DB, but it currently fails because gcloud CLI is not setup on tags:
https://github.com/Substra/orchestrator/runs/8225048401?check_suite_focus=true

<!-- Please include a summary of your changes. -->
This attempts to fix the issue by enabling the setup steps on tag events.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
- with a [test tag to trigger the workflow](https://github.com/Substra/orchestrator/runs/8225476435?check_suite_focus=true)

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
