### PR TITLE
chore: update docker image dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Images are built using `protoc-gen-go` v1.18.1, `grpc_health_probe` v0.4.12 and `migrate` v1.28.1
+
+
 ## [0.26.0] - 2022-09-07
 
 ### Removed

--- a/docker/orchestrator-chaincode/Dockerfile
+++ b/docker/orchestrator-chaincode/Dockerfile
@@ -14,7 +14,7 @@ ENV GO111MODULE=on
 ENV SRC_DIR=/usr/src/chaincode
 
 # Install protobuf codegen dependencies
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0 && \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
 WORKDIR ${SRC_DIR}

--- a/docker/orchestrator-server/Dockerfile
+++ b/docker/orchestrator-server/Dockerfile
@@ -14,13 +14,13 @@ ARG VERSION=dev
 ENV GO111MODULE=on
 ENV SRC_DIR=/usr/src/orchestrator
 
-RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64 -O /bin/grpc_health_probe && chmod +x /bin/grpc_health_probe
+RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.12/grpc_health_probe-linux-amd64 -O /bin/grpc_health_probe && chmod +x /bin/grpc_health_probe
 
 # Install migration tool
-RUN wget -qO- https://github.com/golang-migrate/migrate/releases/download/v4.15.1/migrate.linux-amd64.tar.gz | tar xzf - -C /bin/
+RUN wget -qO- https://github.com/golang-migrate/migrate/releases/download/v4.15.2/migrate.linux-amd64.tar.gz | tar xzf - -C /bin/
 
 # Install protobuf codegen dependencies
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0 && \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
 WORKDIR ${SRC_DIR}


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->
This updates:

- protoc-gen-go to v1.18.1 from v1.18.0
- grpc_health_probe to v0.4.12 from v0.4.11
- migrate to v1.28.1 from v1.28.0

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

- CI

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
