### PR TITLE
fix: rename DeleteOutput to DisableOutput in computetask smart contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Images are built using `protoc-gen-go` v1.18.1, `grpc_health_probe` v0.4.12 and `migrate` v1.28.1
 
+### Fixed
+
+- Disable output RPC on distributed mode
 
 ## [0.26.0] - 2022-09-07
 

--- a/chaincode/computetask/contract.go
+++ b/chaincode/computetask/contract.go
@@ -190,7 +190,7 @@ func (s *SmartContract) GetTaskInputAssets(ctx ledger.TransactionContext, wrappe
 	return wrapped, nil
 }
 
-func (s *SmartContract) DeleteOutput(ctx ledger.TransactionContext, wrapper *communication.Wrapper) (*communication.Wrapper, error) {
+func (s *SmartContract) DisableOutput(ctx ledger.TransactionContext, wrapper *communication.Wrapper) (*communication.Wrapper, error) {
 	provider, err := ctx.GetProvider()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

At the time I created the disable output feature it was not tested as no client was using it. Today I introduced an end to end test that use this feature (https://github.com/Substra/substra-tests/pull/201) and it broke in distributed mode because the smart contract entry `DisableOutput` did not exit. This PR addresses that, by renaming the `DeleteOutput` smart contract entry to `DisableOutput` which is the right name.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

End to end tests.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
