### PR TITLE
feat: assign worker from NewComputeTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Worker field on NewComputeTask mandatory for tasks without input data
+
+### Deprecated
+
+- NewAggregateTrainTaskData.worker: use NewComputeTask.Worker field instead
+
 ## [0.26.1] - 2022-09-12
 
 ### Changed

--- a/docs/assets/computetask.md
+++ b/docs/assets/computetask.md
@@ -100,3 +100,12 @@ Basically:
 
 - only the owner can cancel a task
 - only the worker can act on a task processing (DOING/DONE/FAILED)
+
+## Worker
+
+A task is processed on a specific worker.
+
+Most of the time, the worker can be inferred from task inputs: it should be where the data is, ie. the datamanager's owner.
+In those cases, the `NewComputeTask.Worker` field is **ignored**.
+
+For tasks without data input (such as model aggregation tasks), the worker **MUST** explicitly be set on task creation.

--- a/docs/assets/computetask.md
+++ b/docs/assets/computetask.md
@@ -106,6 +106,6 @@ Basically:
 A task is processed on a specific worker.
 
 Most of the time, the worker can be inferred from task inputs: it should be where the data is, ie. the datamanager's owner.
-In those cases, the `NewComputeTask.Worker` field is **ignored**.
+In those cases, the `NewComputeTask.Worker` field is optional and an error will be returned if the specified worker does not match the data owner.
 
 For tasks without data input (such as model aggregation tasks), the worker **MUST** explicitly be set on task creation.

--- a/e2e/client/option.go
+++ b/e2e/client/option.go
@@ -427,6 +427,7 @@ func (o *AggregateTaskOptions) GetNewTask(ks *KeyStore) *asset.NewComputeTask {
 		Category:       asset.ComputeTaskCategory_TASK_AGGREGATE,
 		AlgoKey:        ks.GetKey(o.AlgoRef),
 		ComputePlanKey: ks.GetKey(o.PlanRef),
+		Worker:         o.Worker,
 		Data: &asset.NewComputeTask_Aggregate{
 			Aggregate: &asset.NewAggregateTrainTaskData{
 				Worker: o.Worker,

--- a/lib/asset/computetask.proto
+++ b/lib/asset/computetask.proto
@@ -165,7 +165,8 @@ message AggregateTrainTaskData {
 }
 
 message NewAggregateTrainTaskData {
-  string worker = 2;
+  // worker property is deprecated, pass the worker through NewComputeTask.Worker
+  string worker = 2 [deprecated=true];
 }
 
 message RegisterTasksParam {

--- a/lib/asset/computetask.proto
+++ b/lib/asset/computetask.proto
@@ -86,6 +86,7 @@ message NewComputeTask {
   ComputeTaskCategory category = 2;
   string algo_key = 3;
   string compute_plan_key = 4;
+  string worker = 6;
   // This property is now ignored, task parents are determined from the inputs.
   repeated string parent_task_keys = 5 [deprecated=true];
   oneof data {

--- a/lib/asset/computetask_validation.go
+++ b/lib/asset/computetask_validation.go
@@ -31,7 +31,8 @@ func (t *NewComputeTask) Validate() error {
 	case *NewComputeTask_Composite:
 		return d.Composite.Validate()
 	case *NewComputeTask_Aggregate:
-		return d.Aggregate.Validate()
+		// Nothing to validate, worker should be passed as NewComputeTask.Worker
+		return nil
 	case *NewComputeTask_Test:
 		return d.Test.Validate()
 	case *NewComputeTask_Train:
@@ -69,12 +70,6 @@ func (t *NewPredictTaskData) Validate() error {
 		validation.Field(&t.DataManagerKey, validation.Required, is.UUID),
 		validation.Field(&t.DataSampleKeys, validation.Required, validation.Each(validation.Required, is.UUID)))
 
-}
-
-func (t *NewAggregateTrainTaskData) Validate() error {
-	return validation.ValidateStruct(t,
-		validation.Field(&t.Worker, validation.Required),
-	)
 }
 
 func (p *ApplyTaskActionParam) Validate() error {

--- a/lib/asset/computetask_validation_test.go
+++ b/lib/asset/computetask_validation_test.go
@@ -340,31 +340,6 @@ func TestNewTestTaskDataValidation(t *testing.T) {
 	}
 }
 
-func TestNewAggregateTrainTaskDataValidation(t *testing.T) {
-	valid := &NewAggregateTrainTaskData{
-		Worker: "MyORG2MSP",
-	}
-	empty := &NewAggregateTrainTaskData{}
-
-	cases := map[string]struct {
-		valid bool
-		data  *NewAggregateTrainTaskData
-	}{
-		"valid": {valid: true, data: valid},
-		"empty": {valid: false, data: empty},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			if c.valid {
-				assert.NoError(t, c.data.Validate())
-			} else {
-				assert.Error(t, c.data.Validate())
-			}
-		})
-	}
-}
-
 func TestNewCompositeTrainTaskDataValidation(t *testing.T) {
 	valid := &NewCompositeTrainTaskData{
 		DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",

--- a/lib/service/computetask.go
+++ b/lib/service/computetask.go
@@ -1082,6 +1082,12 @@ func (s *ComputeTaskService) getTaskWorker(input *asset.NewComputeTask, algo *as
 		inferredWorker = input.Worker
 	}
 
+	// Make sure the organization exists
+	_, err := s.GetOrganizationService().GetOrganization(inferredWorker)
+	if err != nil {
+		return "", err
+	}
+
 	return inferredWorker, nil
 }
 

--- a/lib/service/computetask_test.go
+++ b/lib/service/computetask_test.go
@@ -787,8 +787,6 @@ func TestSetAggregateData(t *testing.T) {
 		},
 	}
 
-	// check organization existence
-	ns.On("GetOrganization", "org3").Once().Return(&asset.Organization{Id: "org3"}, nil)
 	// used by permissions service
 	ns.On("GetAllOrganizations").Once().Return([]*asset.Organization{{Id: "org1"}, {Id: "org2"}, {Id: "org3"}}, nil)
 
@@ -797,7 +795,6 @@ func TestSetAggregateData(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "org3", task.Worker)
 	assert.ElementsMatch(t, task.LogsPermission.AuthorizedIds, []string{"org1", "org2", "org4"})
 
 	ns.AssertExpectations(t)
@@ -2263,6 +2260,25 @@ func TestGetTaskWorker(t *testing.T) {
 					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model2"}},
 				},
 				Worker: "worker",
+			},
+			algo: &asset.Algo{
+				Inputs: map[string]*asset.AlgoInput{
+					"model": {Kind: asset.AssetKind_ASSET_MODEL},
+				},
+			},
+			worker: "worker",
+		},
+		"aggregation with legacy worker field": {
+			newTask: &asset.NewComputeTask{
+				Inputs: []*asset.ComputeTaskInput{
+					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model1"}},
+					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model2"}},
+				},
+				Data: &asset.NewComputeTask_Aggregate{
+					Aggregate: &asset.NewAggregateTrainTaskData{
+						Worker: "worker", //  nolint: staticcheck
+					},
+				},
 			},
 			algo: &asset.Algo{
 				Inputs: map[string]*asset.AlgoInput{


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
This feature will allow to specify the worker on task creation. That's a first step to remove task-specific data and, eventually, task categories.
For tasks having a datamanager, the worker is inferred from the manager's owner and the input is **ignored**.
Tasks not having input data, such as our current aggregation tasks, explicitly setting the worker is mandatory.

For now, aggregate tasks will fallback to task-specific data if the worker is not set.
This means that there is some throwaway code here and there: it will disappear once all consumers have transitioned to the new field.

<!-- Please include a summary of your changes. -->

## How has this been tested?

- unit test
- e2e

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
