### PR TITLE
fix: only use aggregate worker as fallback

### DIFF
--- a/lib/service/computetask.go
+++ b/lib/service/computetask.go
@@ -1073,11 +1073,10 @@ func (s *ComputeTaskService) getTaskWorker(input *asset.NewComputeTask, algo *as
 		return dm.Owner, nil
 	}
 
-	if agg, ok := input.Data.(*asset.NewComputeTask_Aggregate); ok {
-		return agg.Aggregate.Worker, nil //  nolint: staticcheck
-	}
-
 	if input.Worker == "" {
+		if agg, ok := input.Data.(*asset.NewComputeTask_Aggregate); ok {
+			return agg.Aggregate.Worker, nil //  nolint: staticcheck
+		}
 		return "", orcerrors.NewBadRequest("Worker cannot be inferred and must be explicitly set")
 	}
 

--- a/lib/service/computetask_test.go
+++ b/lib/service/computetask_test.go
@@ -2287,6 +2287,24 @@ func TestGetTaskWorker(t *testing.T) {
 			},
 			worker: "worker",
 		},
+		"aggregation without legacy worker field": {
+			newTask: &asset.NewComputeTask{
+				Inputs: []*asset.ComputeTaskInput{
+					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model1"}},
+					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model2"}},
+				},
+				Data: &asset.NewComputeTask_Aggregate{
+					Aggregate: &asset.NewAggregateTrainTaskData{},
+				},
+				Worker: "worker",
+			},
+			algo: &asset.Algo{
+				Inputs: map[string]*asset.AlgoInput{
+					"model": {Kind: asset.AssetKind_ASSET_MODEL},
+				},
+			},
+			worker: "worker",
+		},
 	}
 
 	dms := new(MockDataManagerAPI)


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
In #18 , I messed up the implementation and always used the aggregation data worker instead of just falling back in case the task worker was not set.

This PR fixes that.

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
- unit test

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
