### PR TITLE
chore: remove NewComputeTask.parent_task_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - NewAggregateTrainTaskData.worker: use NewComputeTask.Worker field instead
 
+### Removed
+
+- `NewComputeTask.parent_task_keys` which was deprecated since 0.26.0
+
 ## [0.26.1] - 2022-09-12
 
 ### Changed

--- a/lib/asset/computetask.proto
+++ b/lib/asset/computetask.proto
@@ -82,13 +82,14 @@ message ComputeTask {
 }
 
 message NewComputeTask {
+  reserved 5;
+  reserved "parent_task_keys";
+
   string key = 1;
   ComputeTaskCategory category = 2;
   string algo_key = 3;
   string compute_plan_key = 4;
   string worker = 6;
-  // This property is now ignored, task parents are determined from the inputs.
-  repeated string parent_task_keys = 5 [deprecated=true];
   oneof data {
     NewTestTaskData test = 12;
     NewTrainTaskData train = 13;

--- a/lib/asset/computetask_validation.go
+++ b/lib/asset/computetask_validation.go
@@ -17,7 +17,6 @@ func (t *NewComputeTask) Validate() error {
 		validation.Field(&t.AlgoKey, validation.Required, is.UUID),
 		validation.Field(&t.ComputePlanKey, validation.Required, is.UUID),
 		validation.Field(&t.Metadata, validation.By(validateMetadata)),
-		validation.Field(&t.ParentTaskKeys, validation.Each(is.UUID)),
 		validation.Field(&t.Data, validation.Required),
 		validation.Field(&t.Inputs, validation.By(validateTaskInputs)),
 		validation.Field(&t.Outputs, validation.By(validateTaskOutputs)),

--- a/lib/asset/computetask_validation_test.go
+++ b/lib/asset/computetask_validation_test.go
@@ -51,7 +51,6 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
 		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
 		Metadata:       map[string]string{"test": "indeed"},
-		ParentTaskKeys: []string{"7ae86bc1-aa4a-492f-90a6-ad5e686afb8f"},
 		Data: &NewComputeTask_Train{
 			Train: &NewTrainTaskData{
 				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
@@ -64,7 +63,6 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		Category:       ComputeTaskCategory_TASK_TRAIN,
 		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
 		Metadata:       map[string]string{"test": "indeed"},
-		ParentTaskKeys: []string{"7ae86bc1-aa4a-492f-90a6-ad5e686afb8f"},
 		Data: &NewComputeTask_Train{
 			Train: &NewTrainTaskData{
 				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
@@ -73,11 +71,10 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		},
 	}
 	missingComputePlan := &NewComputeTask{
-		Key:            "867852b4-8419-4d52-8862-d5db823095be",
-		Category:       ComputeTaskCategory_TASK_TRAIN,
-		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
-		Metadata:       map[string]string{"test": "indeed"},
-		ParentTaskKeys: []string{"7ae86bc1-aa4a-492f-90a6-ad5e686afb8f"},
+		Key:      "867852b4-8419-4d52-8862-d5db823095be",
+		Category: ComputeTaskCategory_TASK_TRAIN,
+		AlgoKey:  "867852b4-8419-4d52-8862-d5db823095be",
+		Metadata: map[string]string{"test": "indeed"},
 		Data: &NewComputeTask_Train{
 			Train: &NewTrainTaskData{
 				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
@@ -91,20 +88,6 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
 		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
 		Metadata:       map[string]string{"test": "indeed"},
-		ParentTaskKeys: []string{"7ae86bc1-aa4a-492f-90a6-ad5e686afb8f"},
-	}
-	invalidParent := &NewComputeTask{
-		Key:            "867852b4-8419-4d52-8862-d5db823095be",
-		Category:       ComputeTaskCategory_TASK_TRAIN,
-		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
-		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
-		ParentTaskKeys: []string{"7ae86bc1-aa4a-492f-90a6-ad5e686afb8f", "3fd0f5d823fc459e8316da46d2f6dbaa"},
-		Data: &NewComputeTask_Train{
-			Train: &NewTrainTaskData{
-				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
-				DataSampleKeys: []string{"85e39014-ae2e-4fa4-b05b-4437076a4fa7", "8a90a6e3-2e7e-4c9d-9ed3-47b99942d0a8"},
-			},
-		},
 	}
 	invalidOutputPermissionsIdentifier := &NewComputeTask{
 		Key:            "867852b4-8419-4d52-8862-d5db823095be",
@@ -257,7 +240,6 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		"missing algokey":                       {valid: false, newTask: missingAlgo},
 		"missing compute plan":                  {valid: false, newTask: missingComputePlan},
 		"missing train data":                    {valid: false, newTask: missingData},
-		"invalid parent":                        {valid: false, newTask: invalidParent},
 		"missing input identifier":              {valid: false, newTask: missingInputIdentifier},
 		"missing input ref":                     {valid: false, newTask: missingInputRef},
 		"invalid input ref":                     {valid: false, newTask: invalidInputRef},

--- a/lib/service/computetask_test.go
+++ b/lib/service/computetask_test.go
@@ -152,32 +152,6 @@ func TestRegisterTaskConflict(t *testing.T) {
 	provider.AssertExpectations(t)
 }
 
-func TestRegisterTaskInvalidParents(t *testing.T) {
-	invalidTrainTask := &asset.NewComputeTask{
-		Key:            "867852b4-8419-4d52-8862-d5db823095be",
-		Category:       asset.ComputeTaskCategory_TASK_TRAIN,
-		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
-		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
-		ParentTaskKeys: []string{"3fd0f5d823fc459e8316da46d2f6dbaa"},
-		Data: &asset.NewComputeTask_Train{
-			Train: &asset.NewTrainTaskData{
-				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
-				DataSampleKeys: []string{"85e39014-ae2e-4fa4-b05b-4437076a4fa7", "8a90a6e3-2e7e-4c9d-9ed3-47b99942d0a8"},
-			},
-		},
-	}
-
-	provider := newMockedProvider()
-	service := NewComputeTaskService(provider)
-
-	_, err := service.RegisterTasks([]*asset.NewComputeTask{invalidTrainTask}, "test")
-	orcError := new(orcerrors.OrcError)
-	assert.True(t, errors.As(err, &orcError))
-	assert.Equal(t, orcerrors.ErrInvalidAsset, orcError.Kind)
-
-	provider.AssertExpectations(t)
-}
-
 func TestRegisterTrainTask(t *testing.T) {
 	dbal := new(persistence.MockDBAL)
 	es := new(MockEventAPI)


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
The backend does not send parent task keys since https://github.com/Substra/substra-backend/pull/455.
Let's remove this deprecated property.

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
- CI

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
