### PR TITLE
fix: task outputs events come after their asset creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Task outputs events come after their referenced asset creation event
+
 ## [0.27.0] - 2022-09-19
 
 ### Added

--- a/e2e/model_test.go
+++ b/e2e/model_test.go
@@ -29,7 +29,7 @@ func TestRegisterModel(t *testing.T) {
 
 	taskEvents := appClient.QueryEvents(&asset.EventQueryFilter{AssetKey: appClient.GetKeyStore().GetKey(client.DefaultTrainTaskRef)}, "", 10)
 
-	// 3 events: start, model creation, task output asset creation
+	// 3 events: creation, start, task output asset creation
 	require.Equalf(t, 3, len(taskEvents.Events), "events: %v", taskEvents.Events)
 
 	retrievedModel := appClient.GetModel(client.DefaultModelRef)

--- a/lib/service/model.go
+++ b/lib/service/model.go
@@ -124,16 +124,6 @@ func (s *ModelService) registerModel(newModel *asset.NewModel, requester string,
 		return nil, err
 	}
 
-	outputAsset := &asset.ComputeTaskOutputAsset{
-		ComputeTaskKey:              newModel.ComputeTaskKey,
-		ComputeTaskOutputIdentifier: newModel.ComputeTaskOutputIdentifier,
-		AssetKind:                   asset.AssetKind_ASSET_MODEL,
-		AssetKey:                    newModel.Key,
-	}
-	err = s.GetComputeTaskService().addComputeTaskOutputAsset(outputAsset)
-	if err != nil {
-		return nil, err
-	}
 	event := &asset.Event{
 		EventKind: asset.EventKind_EVENT_ASSET_CREATED,
 		AssetKey:  model.Key,
@@ -141,6 +131,16 @@ func (s *ModelService) registerModel(newModel *asset.NewModel, requester string,
 		Asset:     &asset.Event_Model{Model: model},
 	}
 	err = s.GetEventService().RegisterEvents(event)
+	if err != nil {
+		return nil, err
+	}
+	outputAsset := &asset.ComputeTaskOutputAsset{
+		ComputeTaskKey:              newModel.ComputeTaskKey,
+		ComputeTaskOutputIdentifier: newModel.ComputeTaskOutputIdentifier,
+		AssetKind:                   asset.AssetKind_ASSET_MODEL,
+		AssetKey:                    newModel.Key,
+	}
+	err = s.GetComputeTaskService().addComputeTaskOutputAsset(outputAsset)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/service/model_test.go
+++ b/lib/service/model_test.go
@@ -235,7 +235,6 @@ func TestRegisterTrainModel(t *testing.T) {
 		AssetKind:                   asset.AssetKind_ASSET_MODEL,
 		AssetKey:                    model.Key,
 	}
-	cts.On("addComputeTaskOutputAsset", output).Once().Return(nil)
 
 	event := &asset.Event{
 		AssetKind: asset.AssetKind_ASSET_MODEL,
@@ -243,7 +242,10 @@ func TestRegisterTrainModel(t *testing.T) {
 		EventKind: asset.EventKind_EVENT_ASSET_CREATED,
 		Asset:     &asset.Event_Model{Model: storedModel},
 	}
-	es.On("RegisterEvents", event).Once().Return(nil)
+
+	cts.On("addComputeTaskOutputAsset", output).Once().Return(nil).NotBefore(
+		es.On("RegisterEvents", event).Once().Return(nil),
+	)
 
 	_, err := service.registerModel(model, "test", persistence.ComputeTaskOutputCounter{}, task)
 	assert.NoError(t, err)

--- a/lib/service/performance.go
+++ b/lib/service/performance.go
@@ -107,16 +107,6 @@ func (s *PerformanceService) RegisterPerformance(newPerf *asset.NewPerformance, 
 		return nil, err
 	}
 
-	outputAsset := &asset.ComputeTaskOutputAsset{
-		ComputeTaskKey:              newPerf.ComputeTaskKey,
-		ComputeTaskOutputIdentifier: newPerf.ComputeTaskOutputIdentifier,
-		AssetKind:                   asset.AssetKind_ASSET_PERFORMANCE,
-		AssetKey:                    perf.GetKey(),
-	}
-	err = s.GetComputeTaskService().addComputeTaskOutputAsset(outputAsset)
-	if err != nil {
-		return nil, err
-	}
 	event := &asset.Event{
 		EventKind: asset.EventKind_EVENT_ASSET_CREATED,
 		AssetKey:  perf.GetKey(),
@@ -124,6 +114,16 @@ func (s *PerformanceService) RegisterPerformance(newPerf *asset.NewPerformance, 
 		Asset:     &asset.Event_Performance{Performance: perf},
 	}
 	err = s.GetEventService().RegisterEvents(event)
+	if err != nil {
+		return nil, err
+	}
+	outputAsset := &asset.ComputeTaskOutputAsset{
+		ComputeTaskKey:              newPerf.ComputeTaskKey,
+		ComputeTaskOutputIdentifier: newPerf.ComputeTaskOutputIdentifier,
+		AssetKind:                   asset.AssetKind_ASSET_PERFORMANCE,
+		AssetKey:                    perf.GetKey(),
+	}
+	err = s.GetComputeTaskService().addComputeTaskOutputAsset(outputAsset)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/service/performance_test.go
+++ b/lib/service/performance_test.go
@@ -74,7 +74,6 @@ func TestRegisterPerformance(t *testing.T) {
 		AssetKind:                   asset.AssetKind_ASSET_PERFORMANCE,
 		AssetKey:                    stored.GetKey(),
 	}
-	cts.On("addComputeTaskOutputAsset", output).Once().Return(nil)
 
 	event := &asset.Event{
 		AssetKind: asset.AssetKind_ASSET_PERFORMANCE,
@@ -82,7 +81,10 @@ func TestRegisterPerformance(t *testing.T) {
 		EventKind: asset.EventKind_EVENT_ASSET_CREATED,
 		Asset:     &asset.Event_Performance{Performance: stored},
 	}
-	es.On("RegisterEvents", event).Once().Return(nil)
+
+	cts.On("addComputeTaskOutputAsset", output).Once().Return(nil).NotBefore(
+		es.On("RegisterEvents", event).Once().Return(nil),
+	)
 
 	_, err := service.RegisterPerformance(perf, "test")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->
Events were not dispatched in the appropriate order: task output came before the referenced asset was registered.
Both models and performances were impacted.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
- unit test were updated with a specific assertion on event registration order.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated