### PR TITLE
feat: remove worker field from aggregate task data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Task outputs events come after their referenced asset creation event
 
+### Removed
+
+- Worker field on NewAggregateTrainTaskData, use NewComputeTask.Worker field instead
+
 ## [0.27.0] - 2022-09-19
 
 ### Added

--- a/e2e/client/option.go
+++ b/e2e/client/option.go
@@ -429,9 +429,7 @@ func (o *AggregateTaskOptions) GetNewTask(ks *KeyStore) *asset.NewComputeTask {
 		ComputePlanKey: ks.GetKey(o.PlanRef),
 		Worker:         o.Worker,
 		Data: &asset.NewComputeTask_Aggregate{
-			Aggregate: &asset.NewAggregateTrainTaskData{
-				Worker: o.Worker,
-			},
+			Aggregate: &asset.NewAggregateTrainTaskData{},
 		},
 		Inputs:  GetNewTaskInputs(ks, o.Inputs),
 		Outputs: o.Outputs,

--- a/lib/asset/computetask.proto
+++ b/lib/asset/computetask.proto
@@ -166,8 +166,8 @@ message AggregateTrainTaskData {
 }
 
 message NewAggregateTrainTaskData {
-  // worker property is deprecated, pass the worker through NewComputeTask.Worker
-  string worker = 2 [deprecated=true];
+  reserved 2;
+  reserved "worker";
 }
 
 message RegisterTasksParam {

--- a/lib/service/computetask.go
+++ b/lib/service/computetask.go
@@ -1033,9 +1033,6 @@ func (s *ComputeTaskService) getTaskWorker(input *asset.NewComputeTask, algo *as
 	}
 
 	if input.Worker == "" {
-		if agg, ok := input.Data.(*asset.NewComputeTask_Aggregate); ok {
-			return agg.Aggregate.Worker, nil //  nolint: staticcheck
-		}
 		return "", orcerrors.NewBadRequest("Worker cannot be inferred and must be explicitly set")
 	}
 

--- a/lib/service/computetask_test.go
+++ b/lib/service/computetask_test.go
@@ -738,9 +738,7 @@ func TestSetAggregateData(t *testing.T) {
 	taskInput := &asset.NewComputeTask{
 		AlgoKey: "algoUuid",
 	}
-	specificInput := &asset.NewAggregateTrainTaskData{
-		Worker: "org3",
-	}
+	specificInput := &asset.NewAggregateTrainTaskData{}
 	task := &asset.ComputeTask{
 		Owner:    "org1",
 		Category: asset.ComputeTaskCategory_TASK_AGGREGATE,
@@ -2106,43 +2104,6 @@ func TestGetTaskWorker(t *testing.T) {
 				Inputs: []*asset.ComputeTaskInput{
 					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model1"}},
 					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model2"}},
-				},
-				Worker: "worker",
-			},
-			algo: &asset.Algo{
-				Inputs: map[string]*asset.AlgoInput{
-					"model": {Kind: asset.AssetKind_ASSET_MODEL},
-				},
-			},
-			worker: "worker",
-		},
-		"aggregation with legacy worker field": {
-			newTask: &asset.NewComputeTask{
-				Inputs: []*asset.ComputeTaskInput{
-					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model1"}},
-					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model2"}},
-				},
-				Data: &asset.NewComputeTask_Aggregate{
-					Aggregate: &asset.NewAggregateTrainTaskData{
-						Worker: "worker", //  nolint: staticcheck
-					},
-				},
-			},
-			algo: &asset.Algo{
-				Inputs: map[string]*asset.AlgoInput{
-					"model": {Kind: asset.AssetKind_ASSET_MODEL},
-				},
-			},
-			worker: "worker",
-		},
-		"aggregation without legacy worker field": {
-			newTask: &asset.NewComputeTask{
-				Inputs: []*asset.ComputeTaskInput{
-					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model1"}},
-					{Identifier: "model", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "uuid:model2"}},
-				},
-				Data: &asset.NewComputeTask_Aggregate{
-					Aggregate: &asset.NewAggregateTrainTaskData{},
 				},
 				Worker: "worker",
 			},


### PR DESCRIPTION
## Description

Remove the worker field from aggregate task data since it was deprecated and not used by any consumers anymore.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
e2e tests.
Result:
```
============ 110 passed, 7 skipped, 7 warnings in 559.00s (0:09:19) ============
```

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated

Hello, it's me stealing cleanup PRs:
 ![](https://media.giphy.com/media/FD0qqdSdzPRde/giphy.gif)