### PR TITLE
feat: remove delete_intermediary_model field from compute plan message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Worker field on NewAggregateTrainTaskData, use NewComputeTask.Worker field instead
 - DisableModel rpc in Model service, use DisableOutput in ComputeTask service instead
 - CanDisableModel rpc in Model service.
+- `delete_intermediary_models` field from the `ComputePlan` and `NewComputePlan` messages.
 
 ## [0.27.0] - 2022-09-19
 

--- a/chaincode/ledger/dbal_computeplan.go
+++ b/chaincode/ledger/dbal_computeplan.go
@@ -13,25 +13,23 @@ import (
 
 // storableComputePlan is a custom representation of asset.ComputePlan to enforce storing without its computed properties.
 type storableComputePlan struct {
-	Key                      string            `json:"key"`
-	Owner                    string            `json:"owner"`
-	DeleteIntermediaryModels bool              `json:"delete_intermediary_models"`
-	CreationDate             *time.Time        `json:"creation_date"`
-	Tag                      string            `json:"tag"`
-	Name                     string            `json:"name"`
-	Metadata                 map[string]string `json:"metadata"`
-	CancelationDate          *time.Time        `json:"cancelation_date"`
+	Key             string            `json:"key"`
+	Owner           string            `json:"owner"`
+	CreationDate    *time.Time        `json:"creation_date"`
+	Tag             string            `json:"tag"`
+	Name            string            `json:"name"`
+	Metadata        map[string]string `json:"metadata"`
+	CancelationDate *time.Time        `json:"cancelation_date"`
 }
 
 // newStorableComputePlan returns a storableComputePlan without its computed properties.
 func newStorableComputePlan(plan *asset.ComputePlan) *storableComputePlan {
 	storablePlan := &storableComputePlan{
-		Key:                      plan.Key,
-		Owner:                    plan.Owner,
-		DeleteIntermediaryModels: plan.DeleteIntermediaryModels,
-		Tag:                      plan.Tag,
-		Name:                     plan.Name,
-		Metadata:                 plan.Metadata,
+		Key:      plan.Key,
+		Owner:    plan.Owner,
+		Tag:      plan.Tag,
+		Name:     plan.Name,
+		Metadata: plan.Metadata,
 	}
 
 	if plan.CreationDate != nil {

--- a/docs/schemas/standalone-database.svg
+++ b/docs/schemas/standalone-database.svg
@@ -5,10 +5,10 @@
  -->
 <!-- Title: postgres Pages: 1 -->
 <svg width="5712pt" height="2527pt"
- viewBox="0.00 0.00 5711.50 2527.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ viewBox="0.00 0.00 5712.00 2527.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 2523)">
 <title>postgres</title>
-<polygon fill="#ffffff" stroke="transparent" points="-4,4 -4,-2523 5707.5,-2523 5707.5,4 -4,4"/>
+<polygon fill="#ffffff" stroke="transparent" points="-4,4 -4,-2523 5708,-2523 5708,4 -4,4"/>
 <!-- public.schema_migrations -->
 <g id="node1" class="node">
 <title>public.schema_migrations</title>
@@ -286,44 +286,41 @@
 <!-- public.compute_plans -->
 <g id="node8" class="node">
 <title>public.compute_plans</title>
-<polygon fill="#efefef" stroke="transparent" points="972,-619.5 972,-654.5 1261,-654.5 1261,-619.5 972,-619.5"/>
-<polygon fill="none" stroke="#000000" points="972,-619.5 972,-654.5 1261,-654.5 1261,-619.5 972,-619.5"/>
-<text text-anchor="start" x="980.8494" y="-632.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.compute_plans</text>
-<text text-anchor="start" x="1154.8968" y="-632.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
-<text text-anchor="start" x="1158.7874" y="-632.3" font-family="Arial" font-size="14.00" fill="#666666">[BASE TABLE]</text>
-<polygon fill="none" stroke="#000000" points="972,-589.5 972,-619.5 1261,-619.5 1261,-589.5 972,-589.5"/>
-<text text-anchor="start" x="979" y="-600.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
-<text text-anchor="start" x="1004.6732" y="-600.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
-<polygon fill="none" stroke="#000000" points="972,-559.5 972,-589.5 1261,-589.5 1261,-559.5 972,-559.5"/>
-<text text-anchor="start" x="979" y="-570.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
-<text text-anchor="start" x="1031.9102" y="-570.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="972,-529.5 972,-559.5 1261,-559.5 1261,-529.5 972,-529.5"/>
-<text text-anchor="start" x="979" y="-540.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
-<text text-anchor="start" x="1021.0056" y="-540.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="972,-499.5 972,-529.5 1261,-529.5 1261,-499.5 972,-499.5"/>
-<text text-anchor="start" x="979" y="-510.9" font-family="Arial" font-size="14.00" fill="#000000">delete_intermediary_models </text>
-<text text-anchor="start" x="1158.697" y="-510.9" font-family="Arial" font-size="14.00" fill="#666666">[boolean]</text>
-<polygon fill="none" stroke="#000000" points="972,-469.5 972,-499.5 1261,-499.5 1261,-469.5 972,-469.5"/>
-<text text-anchor="start" x="979" y="-480.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
-<text text-anchor="start" x="1067.6998" y="-480.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
-<polygon fill="none" stroke="#000000" points="972,-439.5 972,-469.5 1261,-469.5 1261,-439.5 972,-439.5"/>
-<text text-anchor="start" x="979" y="-450.9" font-family="Arial" font-size="14.00" fill="#000000">tag </text>
-<text text-anchor="start" x="1002.3464" y="-450.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="972,-409.5 972,-439.5 1261,-439.5 1261,-409.5 972,-409.5"/>
-<text text-anchor="start" x="979" y="-420.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
-<text text-anchor="start" x="1041.2454" y="-420.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="972,-379.5 972,-409.5 1261,-409.5 1261,-379.5 972,-379.5"/>
-<text text-anchor="start" x="979" y="-390.9" font-family="Arial" font-size="14.00" fill="#000000">name </text>
-<text text-anchor="start" x="1017.899" y="-390.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="972,-349.5 972,-379.5 1261,-379.5 1261,-349.5 972,-349.5"/>
-<text text-anchor="start" x="978.8023" y="-360.9" font-family="Arial" font-size="14.00" fill="#000000">cancelation_date </text>
-<text text-anchor="start" x="1088.5133" y="-360.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="#efefef" stroke="transparent" points="972,-604.5 972,-639.5 1261,-639.5 1261,-604.5 972,-604.5"/>
+<polygon fill="none" stroke="#000000" points="972,-604.5 972,-639.5 1261,-639.5 1261,-604.5 972,-604.5"/>
+<text text-anchor="start" x="980.8494" y="-617.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.compute_plans</text>
+<text text-anchor="start" x="1154.8968" y="-617.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
+<text text-anchor="start" x="1158.7874" y="-617.3" font-family="Arial" font-size="14.00" fill="#666666">[BASE TABLE]</text>
+<polygon fill="none" stroke="#000000" points="972,-574.5 972,-604.5 1261,-604.5 1261,-574.5 972,-574.5"/>
+<text text-anchor="start" x="979" y="-585.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
+<text text-anchor="start" x="1004.6732" y="-585.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
+<polygon fill="none" stroke="#000000" points="972,-544.5 972,-574.5 1261,-574.5 1261,-544.5 972,-544.5"/>
+<text text-anchor="start" x="979" y="-555.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
+<text text-anchor="start" x="1031.9102" y="-555.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="972,-514.5 972,-544.5 1261,-544.5 1261,-514.5 972,-514.5"/>
+<text text-anchor="start" x="979" y="-525.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
+<text text-anchor="start" x="1021.0056" y="-525.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="972,-484.5 972,-514.5 1261,-514.5 1261,-484.5 972,-484.5"/>
+<text text-anchor="start" x="979" y="-495.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
+<text text-anchor="start" x="1067.6998" y="-495.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="none" stroke="#000000" points="972,-454.5 972,-484.5 1261,-484.5 1261,-454.5 972,-454.5"/>
+<text text-anchor="start" x="979" y="-465.9" font-family="Arial" font-size="14.00" fill="#000000">tag </text>
+<text text-anchor="start" x="1002.3464" y="-465.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="972,-424.5 972,-454.5 1261,-454.5 1261,-424.5 972,-424.5"/>
+<text text-anchor="start" x="979" y="-435.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
+<text text-anchor="start" x="1041.2454" y="-435.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="972,-394.5 972,-424.5 1261,-424.5 1261,-394.5 972,-394.5"/>
+<text text-anchor="start" x="979" y="-405.9" font-family="Arial" font-size="14.00" fill="#000000">name </text>
+<text text-anchor="start" x="1017.899" y="-405.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="972,-364.5 972,-394.5 1261,-394.5 1261,-364.5 972,-364.5"/>
+<text text-anchor="start" x="978.8023" y="-375.9" font-family="Arial" font-size="14.00" fill="#000000">cancelation_date </text>
+<text text-anchor="start" x="1088.5133" y="-375.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
 </g>
 <!-- public.compute_tasks&#45;&gt;public.compute_plans -->
 <g id="edge11" class="edge">
 <title>public.compute_tasks:compute_plan_key&#45;&gt;public.compute_plans:key</title>
-<path fill="none" stroke="#000000" d="M1042.6303,-1121.1567C897.048,-1111.2513 961.2721,-889.3409 1053,-764 1110.2777,-685.7333 1203.7223,-776.2667 1261,-698 1285.5416,-664.4653 1302.5556,-604.5 1261,-604.5"/>
-<polygon fill="#000000" stroke="#000000" points="1043.0055,-1121.1691 1052.8511,-1125.9975 1048.0027,-1121.3345 1053,-1121.5 1053,-1121.5 1053,-1121.5 1048.0027,-1121.3345 1053.1489,-1117.0025 1043.0055,-1121.1691 1043.0055,-1121.1691"/>
+<path fill="none" stroke="#000000" d="M1042.6365,-1121.1611C897.2305,-1111.3805 965.3355,-892.2157 1053,-764 1108.9935,-682.1055 1205.0065,-764.8945 1261,-683 1284.4544,-648.6962 1302.5556,-589.5 1261,-589.5"/>
+<polygon fill="#000000" stroke="#000000" points="1043.0053,-1121.1731 1052.8529,-1125.9976 1048.0027,-1121.3365 1053,-1121.5 1053,-1121.5 1053,-1121.5 1048.0027,-1121.3365 1053.1471,-1117.0024 1043.0053,-1121.1731 1043.0053,-1121.1731"/>
 <text text-anchor="start" x="721.2015" y="-1131.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (compute_plan_key) REFERENCES compute_plans(key)</text>
 </g>
 <!-- public.compute_task_categories -->
@@ -440,9 +437,9 @@
 <!-- public.compute_plans&#45;&gt;public.organizations -->
 <g id="edge18" class="edge">
 <title>public.compute_plans:owner&#45;&gt;public.organizations:id</title>
-<path fill="none" stroke="#000000" d="M1271.2664,-544.0059C1424.9453,-528.3838 1118.648,-147.5 1292,-147.5"/>
-<polygon fill="#000000" stroke="#000000" points="1270.9884,-544.0192 1260.7837,-540.0052 1265.9942,-544.2596 1261,-544.5 1261,-544.5 1261,-544.5 1265.9942,-544.2596 1261.2163,-548.9948 1270.9884,-544.0192 1270.9884,-544.0192"/>
-<text text-anchor="start" x="1268.036" y="-554.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (owner, channel) REFERENCES organizations(id, channel)</text>
+<path fill="none" stroke="#000000" d="M1271.3235,-528.9786C1418.2513,-513.2623 1125.3237,-147.5 1292,-147.5"/>
+<polygon fill="#000000" stroke="#000000" points="1270.9873,-528.9955 1260.773,-525.0057 1265.9936,-529.2477 1261,-529.5 1261,-529.5 1261,-529.5 1265.9936,-529.2477 1261.227,-533.9943 1270.9873,-528.9955 1270.9873,-528.9955"/>
+<text text-anchor="start" x="1268.036" y="-539.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (owner, channel) REFERENCES organizations(id, channel)</text>
 </g>
 <!-- public.performances -->
 <g id="node9" class="node">
@@ -857,14 +854,14 @@
 <title>public.algo_inputs:algo_key&#45;&gt;public.algos:key</title>
 <path fill="none" stroke="#000000" d="M2797.8868,-1059.465C2744.6705,-1036.3958 2776.1836,-823.8408 2755,-764 2727.9822,-687.6786 2747.9624,-604.5 2667,-604.5"/>
 <polygon fill="#000000" stroke="#000000" points="2798.1965,-1059.5272 2807.1123,-1065.9116 2803.0983,-1060.5136 2808,-1061.5 2808,-1061.5 2808,-1061.5 2803.0983,-1060.5136 2808.8877,-1057.0884 2798.1965,-1059.5272 2798.1965,-1059.5272"/>
-<text text-anchor="start" x="2564.1045" y="-1071.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (algo_key) REFERENCES algos(key)</text>
+<text text-anchor="start" x="2815.1045" y="-1071.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (algo_key) REFERENCES algos(key)</text>
 </g>
 <!-- public.algo_inputs&#45;&gt;public.asset_kinds -->
 <g id="edge32" class="edge">
 <title>public.algo_inputs:kind&#45;&gt;public.asset_kinds:kind</title>
 <path fill="none" stroke="#000000" d="M2797.7335,-1000.3945C2760.5395,-991.354 2789.7948,-928.7877 2808,-884 2879.4839,-708.1376 3034.5161,-753.8624 3106,-578 3106,-578 2934,-469.5 2934,-469.5"/>
 <polygon fill="#000000" stroke="#000000" points="2798.0575,-1000.4293 2807.5182,-1005.9741 2803.0287,-1000.9646 2808,-1001.5 2808,-1001.5 2808,-1001.5 2803.0287,-1000.9646 2808.4818,-997.0259 2798.0575,-1000.4293 2798.0575,-1000.4293"/>
-<text text-anchor="start" x="2554.1055" y="-1011.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (kind) REFERENCES asset_kinds(kind)</text>
+<text text-anchor="start" x="2815.1055" y="-1011.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (kind) REFERENCES asset_kinds(kind)</text>
 </g>
 <!-- public.algo_outputs -->
 <g id="node25" class="node">
@@ -892,14 +889,14 @@
 <title>public.algo_outputs:algo_key&#45;&gt;public.algos:key</title>
 <path fill="none" stroke="#000000" d="M2426.8407,-1045.6759C2375.7636,-1036.6428 2411.4284,-955.3079 2437,-899 2493.1349,-775.3929 2610.8651,-821.6071 2667,-698 2684.1831,-660.1634 2708.5556,-604.5 2667,-604.5"/>
 <polygon fill="#000000" stroke="#000000" points="2427.0327,-1045.6914 2436.6361,-1050.9853 2432.0164,-1046.0957 2437,-1046.5 2437,-1046.5 2437,-1046.5 2432.0164,-1046.0957 2437.3639,-1042.0147 2427.0327,-1045.6914 2427.0327,-1045.6914"/>
-<text text-anchor="start" x="2255.8545" y="-1030.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (algo_key) REFERENCES algos(key)</text>
+<text text-anchor="start" x="2318.6045" y="-1030.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (algo_key) REFERENCES algos(key)</text>
 </g>
 <!-- public.algo_outputs&#45;&gt;public.asset_kinds -->
 <g id="edge34" class="edge">
 <title>public.algo_outputs:kind&#45;&gt;public.asset_kinds:kind</title>
 <path fill="none" stroke="#000000" d="M2712.985,-985.0599C2809.2146,-955.6152 2694.7223,-484.5 2805,-484.5"/>
 <polygon fill="#000000" stroke="#000000" points="2712.8976,-985.0725 2702.3576,-982.0461 2707.9488,-985.7862 2703,-986.5 2703,-986.5 2703,-986.5 2707.9488,-985.7862 2703.6424,-990.9539 2712.8976,-985.0725 2712.8976,-985.0725"/>
-<text text-anchor="start" x="2579.6055" y="-970.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (kind) REFERENCES asset_kinds(kind)</text>
+<text text-anchor="start" x="2449.1055" y="-996.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (kind) REFERENCES asset_kinds(kind)</text>
 </g>
 <!-- public.compute_task_inputs -->
 <g id="node27" class="node">
@@ -970,65 +967,8 @@
 <polygon fill="#000000" stroke="#000000" points="1461.0137,-1517.9771 1470.7647,-1522.9938 1466.0068,-1518.2386 1471,-1518.5 1471,-1518.5 1471,-1518.5 1466.0068,-1518.2386 1471.2353,-1514.0062 1461.0137,-1517.9771 1461.0137,-1517.9771"/>
 <text text-anchor="start" x="1477.7595" y="-1528.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (compute_task_key) REFERENCES compute_tasks(key)</text>
 </g>
-<!-- public.expanded_compute_plans -->
-<g id="node29" class="node">
-<title>public.expanded_compute_plans</title>
-<polygon fill="#efefef" stroke="transparent" points="4537,-2335.5 4537,-2370.5 4861,-2370.5 4861,-2335.5 4537,-2335.5"/>
-<polygon fill="none" stroke="#000000" points="4537,-2335.5 4537,-2370.5 4861,-2370.5 4861,-2335.5 4537,-2335.5"/>
-<text text-anchor="start" x="4543.7264" y="-2348.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.expanded_compute_plans</text>
-<text text-anchor="start" x="4806.8234" y="-2348.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
-<text text-anchor="start" x="4810.714" y="-2348.3" font-family="Arial" font-size="14.00" fill="#666666">[VIEW]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2305.5 4537,-2335.5 4861,-2335.5 4861,-2305.5 4537,-2305.5"/>
-<text text-anchor="start" x="4544" y="-2316.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
-<text text-anchor="start" x="4569.6732" y="-2316.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2275.5 4537,-2305.5 4861,-2305.5 4861,-2275.5 4537,-2275.5"/>
-<text text-anchor="start" x="4544" y="-2286.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
-<text text-anchor="start" x="4596.9102" y="-2286.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2245.5 4537,-2275.5 4861,-2275.5 4861,-2245.5 4537,-2245.5"/>
-<text text-anchor="start" x="4544" y="-2256.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
-<text text-anchor="start" x="4586.0056" y="-2256.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2215.5 4537,-2245.5 4861,-2245.5 4861,-2215.5 4537,-2215.5"/>
-<text text-anchor="start" x="4544" y="-2226.9" font-family="Arial" font-size="14.00" fill="#000000">delete_intermediary_models </text>
-<text text-anchor="start" x="4723.697" y="-2226.9" font-family="Arial" font-size="14.00" fill="#666666">[boolean]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2185.5 4537,-2215.5 4861,-2215.5 4861,-2185.5 4537,-2185.5"/>
-<text text-anchor="start" x="4544" y="-2196.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
-<text text-anchor="start" x="4632.6998" y="-2196.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2155.5 4537,-2185.5 4861,-2185.5 4861,-2155.5 4537,-2155.5"/>
-<text text-anchor="start" x="4544" y="-2166.9" font-family="Arial" font-size="14.00" fill="#000000">cancelation_date </text>
-<text text-anchor="start" x="4653.711" y="-2166.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2125.5 4537,-2155.5 4861,-2155.5 4861,-2125.5 4537,-2125.5"/>
-<text text-anchor="start" x="4544" y="-2136.9" font-family="Arial" font-size="14.00" fill="#000000">tag </text>
-<text text-anchor="start" x="4567.3464" y="-2136.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2095.5 4537,-2125.5 4861,-2125.5 4861,-2095.5 4537,-2095.5"/>
-<text text-anchor="start" x="4544" y="-2106.9" font-family="Arial" font-size="14.00" fill="#000000">name </text>
-<text text-anchor="start" x="4582.899" y="-2106.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2065.5 4537,-2095.5 4861,-2095.5 4861,-2065.5 4537,-2065.5"/>
-<text text-anchor="start" x="4544" y="-2076.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
-<text text-anchor="start" x="4606.2454" y="-2076.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2035.5 4537,-2065.5 4861,-2065.5 4861,-2035.5 4537,-2035.5"/>
-<text text-anchor="start" x="4544" y="-2046.9" font-family="Arial" font-size="14.00" fill="#000000">task_count </text>
-<text text-anchor="start" x="4615.5848" y="-2046.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-<polygon fill="none" stroke="#000000" points="4537,-2005.5 4537,-2035.5 4861,-2035.5 4861,-2005.5 4537,-2005.5"/>
-<text text-anchor="start" x="4544" y="-2016.9" font-family="Arial" font-size="14.00" fill="#000000">waiting_count </text>
-<text text-anchor="start" x="4633.4698" y="-2016.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-<polygon fill="none" stroke="#000000" points="4537,-1975.5 4537,-2005.5 4861,-2005.5 4861,-1975.5 4537,-1975.5"/>
-<text text-anchor="start" x="4544" y="-1986.9" font-family="Arial" font-size="14.00" fill="#000000">todo_count </text>
-<text text-anchor="start" x="4617.15" y="-1986.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-<polygon fill="none" stroke="#000000" points="4537,-1945.5 4537,-1975.5 4861,-1975.5 4861,-1945.5 4537,-1945.5"/>
-<text text-anchor="start" x="4544" y="-1956.9" font-family="Arial" font-size="14.00" fill="#000000">doing_count </text>
-<text text-anchor="start" x="4624.1486" y="-1956.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-<polygon fill="none" stroke="#000000" points="4537,-1915.5 4537,-1945.5 4861,-1945.5 4861,-1915.5 4537,-1915.5"/>
-<text text-anchor="start" x="4544" y="-1926.9" font-family="Arial" font-size="14.00" fill="#000000">canceled_count </text>
-<text text-anchor="start" x="4645.9312" y="-1926.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-<polygon fill="none" stroke="#000000" points="4537,-1885.5 4537,-1915.5 4861,-1915.5 4861,-1885.5 4537,-1885.5"/>
-<text text-anchor="start" x="4544" y="-1896.9" font-family="Arial" font-size="14.00" fill="#000000">failed_count </text>
-<text text-anchor="start" x="4623.3632" y="-1896.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-<polygon fill="none" stroke="#000000" points="4537,-1855.5 4537,-1885.5 4861,-1885.5 4861,-1855.5 4537,-1855.5"/>
-<text text-anchor="start" x="4544" y="-1866.9" font-family="Arial" font-size="14.00" fill="#000000">done_count </text>
-<text text-anchor="start" x="4621.042" y="-1866.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
-</g>
 <!-- public.compute_task_output_assets -->
-<g id="node30" class="node">
+<g id="node29" class="node">
 <title>public.compute_task_output_assets</title>
 <polygon fill="#efefef" stroke="transparent" points="2413,-2170.5 2413,-2205.5 2810,-2205.5 2810,-2170.5 2413,-2170.5"/>
 <polygon fill="none" stroke="#000000" points="2413,-2170.5 2413,-2205.5 2810,-2205.5 2810,-2170.5 2413,-2170.5"/>
@@ -1066,124 +1006,178 @@
 <text text-anchor="start" x="2420.2685" y="-2165.5" font-family="Arial" font-size="10.00" fill="#000000">FOREIGN KEY (compute_task_key, compute_task_output_identifier) REFERENCES compute_task_outputs(compute_task_key, identifier)</text>
 </g>
 <!-- public.expanded_algos -->
-<g id="node31" class="node">
+<g id="node30" class="node">
 <title>public.expanded_algos</title>
-<polygon fill="#efefef" stroke="transparent" points="4965,-2260.5 4965,-2295.5 5233,-2295.5 5233,-2260.5 4965,-2260.5"/>
-<polygon fill="none" stroke="#000000" points="4965,-2260.5 4965,-2295.5 5233,-2295.5 5233,-2260.5 4965,-2260.5"/>
-<text text-anchor="start" x="4983.2391" y="-2273.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.expanded_algos</text>
-<text text-anchor="start" x="5167.3107" y="-2273.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
-<text text-anchor="start" x="5171.2013" y="-2273.3" font-family="Arial" font-size="14.00" fill="#666666">[VIEW]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2230.5 4965,-2260.5 5233,-2260.5 5233,-2230.5 4965,-2230.5"/>
-<text text-anchor="start" x="4972" y="-2241.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
-<text text-anchor="start" x="4997.6732" y="-2241.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2200.5 4965,-2230.5 5233,-2230.5 5233,-2200.5 4965,-2200.5"/>
-<text text-anchor="start" x="4972" y="-2211.9" font-family="Arial" font-size="14.00" fill="#000000">name </text>
-<text text-anchor="start" x="5010.899" y="-2211.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2170.5 4965,-2200.5 5233,-2200.5 5233,-2170.5 4965,-2170.5"/>
-<text text-anchor="start" x="4972" y="-2181.9" font-family="Arial" font-size="14.00" fill="#000000">description_address </text>
-<text text-anchor="start" x="5101.1416" y="-2181.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2140.5 4965,-2170.5 5233,-2170.5 5233,-2140.5 4965,-2140.5"/>
-<text text-anchor="start" x="4972" y="-2151.9" font-family="Arial" font-size="14.00" fill="#000000">description_checksum </text>
-<text text-anchor="start" x="5114.359" y="-2151.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2110.5 4965,-2140.5 5233,-2140.5 5233,-2110.5 4965,-2110.5"/>
-<text text-anchor="start" x="4972" y="-2121.9" font-family="Arial" font-size="14.00" fill="#000000">algorithm_address </text>
-<text text-anchor="start" x="5091.0196" y="-2121.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2080.5 4965,-2110.5 5233,-2110.5 5233,-2080.5 4965,-2080.5"/>
-<text text-anchor="start" x="4972" y="-2091.9" font-family="Arial" font-size="14.00" fill="#000000">algorithm_checksum </text>
-<text text-anchor="start" x="5104.237" y="-2091.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2050.5 4965,-2080.5 5233,-2080.5 5233,-2050.5 4965,-2050.5"/>
-<text text-anchor="start" x="4972" y="-2061.9" font-family="Arial" font-size="14.00" fill="#000000">permissions </text>
-<text text-anchor="start" x="5050.5554" y="-2061.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="4965,-2020.5 4965,-2050.5 5233,-2050.5 5233,-2020.5 4965,-2020.5"/>
-<text text-anchor="start" x="4972" y="-2031.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
-<text text-anchor="start" x="5014.0056" y="-2031.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="4965,-1990.5 4965,-2020.5 5233,-2020.5 5233,-1990.5 4965,-1990.5"/>
-<text text-anchor="start" x="4971.8079" y="-2001.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
-<text text-anchor="start" x="5060.5077" y="-2001.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
-<polygon fill="none" stroke="#000000" points="4965,-1960.5 4965,-1990.5 5233,-1990.5 5233,-1960.5 4965,-1960.5"/>
-<text text-anchor="start" x="4972" y="-1971.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
-<text text-anchor="start" x="5034.2454" y="-1971.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="4965,-1930.5 4965,-1960.5 5233,-1960.5 5233,-1930.5 4965,-1930.5"/>
-<text text-anchor="start" x="4972" y="-1941.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
-<text text-anchor="start" x="5024.9102" y="-1941.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="#efefef" stroke="transparent" points="4537,-2260.5 4537,-2295.5 4805,-2295.5 4805,-2260.5 4537,-2260.5"/>
+<polygon fill="none" stroke="#000000" points="4537,-2260.5 4537,-2295.5 4805,-2295.5 4805,-2260.5 4537,-2260.5"/>
+<text text-anchor="start" x="4555.2391" y="-2273.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.expanded_algos</text>
+<text text-anchor="start" x="4739.3107" y="-2273.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
+<text text-anchor="start" x="4743.2013" y="-2273.3" font-family="Arial" font-size="14.00" fill="#666666">[VIEW]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2230.5 4537,-2260.5 4805,-2260.5 4805,-2230.5 4537,-2230.5"/>
+<text text-anchor="start" x="4544" y="-2241.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
+<text text-anchor="start" x="4569.6732" y="-2241.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2200.5 4537,-2230.5 4805,-2230.5 4805,-2200.5 4537,-2200.5"/>
+<text text-anchor="start" x="4544" y="-2211.9" font-family="Arial" font-size="14.00" fill="#000000">name </text>
+<text text-anchor="start" x="4582.899" y="-2211.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2170.5 4537,-2200.5 4805,-2200.5 4805,-2170.5 4537,-2170.5"/>
+<text text-anchor="start" x="4544" y="-2181.9" font-family="Arial" font-size="14.00" fill="#000000">description_address </text>
+<text text-anchor="start" x="4673.1416" y="-2181.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2140.5 4537,-2170.5 4805,-2170.5 4805,-2140.5 4537,-2140.5"/>
+<text text-anchor="start" x="4544" y="-2151.9" font-family="Arial" font-size="14.00" fill="#000000">description_checksum </text>
+<text text-anchor="start" x="4686.359" y="-2151.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2110.5 4537,-2140.5 4805,-2140.5 4805,-2110.5 4537,-2110.5"/>
+<text text-anchor="start" x="4544" y="-2121.9" font-family="Arial" font-size="14.00" fill="#000000">algorithm_address </text>
+<text text-anchor="start" x="4663.0196" y="-2121.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2080.5 4537,-2110.5 4805,-2110.5 4805,-2080.5 4537,-2080.5"/>
+<text text-anchor="start" x="4544" y="-2091.9" font-family="Arial" font-size="14.00" fill="#000000">algorithm_checksum </text>
+<text text-anchor="start" x="4676.237" y="-2091.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2050.5 4537,-2080.5 4805,-2080.5 4805,-2050.5 4537,-2050.5"/>
+<text text-anchor="start" x="4544" y="-2061.9" font-family="Arial" font-size="14.00" fill="#000000">permissions </text>
+<text text-anchor="start" x="4622.5554" y="-2061.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4537,-2020.5 4537,-2050.5 4805,-2050.5 4805,-2020.5 4537,-2020.5"/>
+<text text-anchor="start" x="4544" y="-2031.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
+<text text-anchor="start" x="4586.0056" y="-2031.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4537,-1990.5 4537,-2020.5 4805,-2020.5 4805,-1990.5 4537,-1990.5"/>
+<text text-anchor="start" x="4543.8079" y="-2001.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
+<text text-anchor="start" x="4632.5077" y="-2001.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="none" stroke="#000000" points="4537,-1960.5 4537,-1990.5 4805,-1990.5 4805,-1960.5 4537,-1960.5"/>
+<text text-anchor="start" x="4544" y="-1971.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
+<text text-anchor="start" x="4606.2454" y="-1971.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4537,-1930.5 4537,-1960.5 4805,-1960.5 4805,-1930.5 4537,-1930.5"/>
+<text text-anchor="start" x="4544" y="-1941.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
+<text text-anchor="start" x="4596.9102" y="-1941.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
 </g>
 <!-- public.expanded_compute_tasks -->
-<g id="node32" class="node">
+<g id="node31" class="node">
 <title>public.expanded_compute_tasks</title>
-<polygon fill="#efefef" stroke="transparent" points="5338,-2440.5 5338,-2475.5 5661,-2475.5 5661,-2440.5 5338,-2440.5"/>
-<polygon fill="none" stroke="#000000" points="5338,-2440.5 5338,-2475.5 5661,-2475.5 5661,-2440.5 5338,-2440.5"/>
-<text text-anchor="start" x="5344.7286" y="-2453.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.expanded_compute_tasks</text>
-<text text-anchor="start" x="5606.8212" y="-2453.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
-<text text-anchor="start" x="5610.7118" y="-2453.3" font-family="Arial" font-size="14.00" fill="#666666">[VIEW]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2410.5 5338,-2440.5 5661,-2440.5 5661,-2410.5 5338,-2410.5"/>
-<text text-anchor="start" x="5345" y="-2421.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
-<text text-anchor="start" x="5370.6732" y="-2421.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2380.5 5338,-2410.5 5661,-2410.5 5661,-2380.5 5338,-2380.5"/>
-<text text-anchor="start" x="5345" y="-2391.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
-<text text-anchor="start" x="5397.9102" y="-2391.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2350.5 5338,-2380.5 5661,-2380.5 5661,-2350.5 5338,-2350.5"/>
-<text text-anchor="start" x="5345" y="-2361.9" font-family="Arial" font-size="14.00" fill="#000000">compute_plan_key </text>
-<text text-anchor="start" x="5466.3744" y="-2361.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2320.5 5338,-2350.5 5661,-2350.5 5661,-2320.5 5338,-2320.5"/>
-<text text-anchor="start" x="5345" y="-2331.9" font-family="Arial" font-size="14.00" fill="#000000">status </text>
-<text text-anchor="start" x="5386.237" y="-2331.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2290.5 5338,-2320.5 5661,-2320.5 5661,-2290.5 5338,-2290.5"/>
-<text text-anchor="start" x="5345" y="-2301.9" font-family="Arial" font-size="14.00" fill="#000000">category </text>
-<text text-anchor="start" x="5402.5722" y="-2301.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2260.5 5338,-2290.5 5661,-2290.5 5661,-2260.5 5338,-2260.5"/>
-<text text-anchor="start" x="5345" y="-2271.9" font-family="Arial" font-size="14.00" fill="#000000">worker </text>
-<text text-anchor="start" x="5390.8836" y="-2271.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2230.5 5338,-2260.5 5661,-2260.5 5661,-2230.5 5338,-2230.5"/>
-<text text-anchor="start" x="5345" y="-2241.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
-<text text-anchor="start" x="5387.0056" y="-2241.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2200.5 5338,-2230.5 5661,-2230.5 5661,-2200.5 5338,-2200.5"/>
-<text text-anchor="start" x="5345" y="-2211.9" font-family="Arial" font-size="14.00" fill="#000000">rank </text>
-<text text-anchor="start" x="5376.1164" y="-2211.9" font-family="Arial" font-size="14.00" fill="#666666">[integer]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2170.5 5338,-2200.5 5661,-2200.5 5661,-2170.5 5338,-2170.5"/>
-<text text-anchor="start" x="5345" y="-2181.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
-<text text-anchor="start" x="5433.6998" y="-2181.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2140.5 5338,-2170.5 5661,-2170.5 5661,-2140.5 5338,-2140.5"/>
-<text text-anchor="start" x="5345" y="-2151.9" font-family="Arial" font-size="14.00" fill="#000000">logs_permission </text>
-<text text-anchor="start" x="5450.0098" y="-2151.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2110.5 5338,-2140.5 5661,-2140.5 5661,-2110.5 5338,-2110.5"/>
-<text text-anchor="start" x="5345" y="-2121.9" font-family="Arial" font-size="14.00" fill="#000000">task_data </text>
-<text text-anchor="start" x="5409.5848" y="-2121.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2080.5 5338,-2110.5 5661,-2110.5 5661,-2080.5 5338,-2080.5"/>
-<text text-anchor="start" x="5345" y="-2091.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
-<text text-anchor="start" x="5407.2454" y="-2091.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2050.5 5338,-2080.5 5661,-2080.5 5661,-2050.5 5338,-2050.5"/>
-<text text-anchor="start" x="5345" y="-2061.9" font-family="Arial" font-size="14.00" fill="#000000">algo_key </text>
-<text text-anchor="start" x="5404.9102" y="-2061.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
-<polygon fill="none" stroke="#000000" points="5338,-2020.5 5338,-2050.5 5661,-2050.5 5661,-2020.5 5338,-2020.5"/>
-<text text-anchor="start" x="5345" y="-2031.9" font-family="Arial" font-size="14.00" fill="#000000">algo_name </text>
-<text text-anchor="start" x="5418.136" y="-2031.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1990.5 5338,-2020.5 5661,-2020.5 5661,-1990.5 5338,-1990.5"/>
-<text text-anchor="start" x="5345" y="-2001.9" font-family="Arial" font-size="14.00" fill="#000000">algo_description_address </text>
-<text text-anchor="start" x="5508.3786" y="-2001.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1960.5 5338,-1990.5 5661,-1990.5 5661,-1960.5 5338,-1960.5"/>
-<text text-anchor="start" x="5345" y="-1971.9" font-family="Arial" font-size="14.00" fill="#000000">algo_description_checksum </text>
-<text text-anchor="start" x="5521.596" y="-1971.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1930.5 5338,-1960.5 5661,-1960.5 5661,-1930.5 5338,-1930.5"/>
-<text text-anchor="start" x="5345" y="-1941.9" font-family="Arial" font-size="14.00" fill="#000000">algo_algorithm_address </text>
-<text text-anchor="start" x="5498.2566" y="-1941.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1900.5 5338,-1930.5 5661,-1930.5 5661,-1900.5 5338,-1900.5"/>
-<text text-anchor="start" x="5345" y="-1911.9" font-family="Arial" font-size="14.00" fill="#000000">algo_algorithm_checksum </text>
-<text text-anchor="start" x="5511.474" y="-1911.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1870.5 5338,-1900.5 5661,-1900.5 5661,-1870.5 5338,-1870.5"/>
-<text text-anchor="start" x="5345" y="-1881.9" font-family="Arial" font-size="14.00" fill="#000000">algo_permissions </text>
-<text text-anchor="start" x="5457.7924" y="-1881.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1840.5 5338,-1870.5 5661,-1870.5 5661,-1840.5 5338,-1840.5"/>
-<text text-anchor="start" x="5345" y="-1851.9" font-family="Arial" font-size="14.00" fill="#000000">algo_owner </text>
-<text text-anchor="start" x="5421.2426" y="-1851.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1810.5 5338,-1840.5 5661,-1840.5 5661,-1810.5 5338,-1810.5"/>
-<text text-anchor="start" x="5345" y="-1821.9" font-family="Arial" font-size="14.00" fill="#000000">algo_creation_date </text>
-<text text-anchor="start" x="5467.9368" y="-1821.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1780.5 5338,-1810.5 5661,-1810.5 5661,-1780.5 5338,-1780.5"/>
-<text text-anchor="start" x="5345" y="-1791.9" font-family="Arial" font-size="14.00" fill="#000000">algo_metadata </text>
-<text text-anchor="start" x="5441.4824" y="-1791.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
-<polygon fill="none" stroke="#000000" points="5338,-1750.5 5338,-1780.5 5661,-1780.5 5661,-1750.5 5338,-1750.5"/>
-<text text-anchor="start" x="5345" y="-1761.9" font-family="Arial" font-size="14.00" fill="#000000">parent_task_keys </text>
-<text text-anchor="start" x="5458.5932" y="-1761.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="#efefef" stroke="transparent" points="4910,-2440.5 4910,-2475.5 5233,-2475.5 5233,-2440.5 4910,-2440.5"/>
+<polygon fill="none" stroke="#000000" points="4910,-2440.5 4910,-2475.5 5233,-2475.5 5233,-2440.5 4910,-2440.5"/>
+<text text-anchor="start" x="4916.7286" y="-2453.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.expanded_compute_tasks</text>
+<text text-anchor="start" x="5178.8212" y="-2453.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
+<text text-anchor="start" x="5182.7118" y="-2453.3" font-family="Arial" font-size="14.00" fill="#666666">[VIEW]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2410.5 4910,-2440.5 5233,-2440.5 5233,-2410.5 4910,-2410.5"/>
+<text text-anchor="start" x="4917" y="-2421.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
+<text text-anchor="start" x="4942.6732" y="-2421.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2380.5 4910,-2410.5 5233,-2410.5 5233,-2380.5 4910,-2380.5"/>
+<text text-anchor="start" x="4917" y="-2391.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
+<text text-anchor="start" x="4969.9102" y="-2391.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2350.5 4910,-2380.5 5233,-2380.5 5233,-2350.5 4910,-2350.5"/>
+<text text-anchor="start" x="4917" y="-2361.9" font-family="Arial" font-size="14.00" fill="#000000">compute_plan_key </text>
+<text text-anchor="start" x="5038.3744" y="-2361.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2320.5 4910,-2350.5 5233,-2350.5 5233,-2320.5 4910,-2320.5"/>
+<text text-anchor="start" x="4917" y="-2331.9" font-family="Arial" font-size="14.00" fill="#000000">status </text>
+<text text-anchor="start" x="4958.237" y="-2331.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2290.5 4910,-2320.5 5233,-2320.5 5233,-2290.5 4910,-2290.5"/>
+<text text-anchor="start" x="4917" y="-2301.9" font-family="Arial" font-size="14.00" fill="#000000">category </text>
+<text text-anchor="start" x="4974.5722" y="-2301.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2260.5 4910,-2290.5 5233,-2290.5 5233,-2260.5 4910,-2260.5"/>
+<text text-anchor="start" x="4917" y="-2271.9" font-family="Arial" font-size="14.00" fill="#000000">worker </text>
+<text text-anchor="start" x="4962.8836" y="-2271.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2230.5 4910,-2260.5 5233,-2260.5 5233,-2230.5 4910,-2230.5"/>
+<text text-anchor="start" x="4917" y="-2241.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
+<text text-anchor="start" x="4959.0056" y="-2241.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2200.5 4910,-2230.5 5233,-2230.5 5233,-2200.5 4910,-2200.5"/>
+<text text-anchor="start" x="4917" y="-2211.9" font-family="Arial" font-size="14.00" fill="#000000">rank </text>
+<text text-anchor="start" x="4948.1164" y="-2211.9" font-family="Arial" font-size="14.00" fill="#666666">[integer]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2170.5 4910,-2200.5 5233,-2200.5 5233,-2170.5 4910,-2170.5"/>
+<text text-anchor="start" x="4917" y="-2181.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
+<text text-anchor="start" x="5005.6998" y="-2181.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2140.5 4910,-2170.5 5233,-2170.5 5233,-2140.5 4910,-2140.5"/>
+<text text-anchor="start" x="4917" y="-2151.9" font-family="Arial" font-size="14.00" fill="#000000">logs_permission </text>
+<text text-anchor="start" x="5022.0098" y="-2151.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2110.5 4910,-2140.5 5233,-2140.5 5233,-2110.5 4910,-2110.5"/>
+<text text-anchor="start" x="4917" y="-2121.9" font-family="Arial" font-size="14.00" fill="#000000">task_data </text>
+<text text-anchor="start" x="4981.5848" y="-2121.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2080.5 4910,-2110.5 5233,-2110.5 5233,-2080.5 4910,-2080.5"/>
+<text text-anchor="start" x="4917" y="-2091.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
+<text text-anchor="start" x="4979.2454" y="-2091.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2050.5 4910,-2080.5 5233,-2080.5 5233,-2050.5 4910,-2050.5"/>
+<text text-anchor="start" x="4917" y="-2061.9" font-family="Arial" font-size="14.00" fill="#000000">algo_key </text>
+<text text-anchor="start" x="4976.9102" y="-2061.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
+<polygon fill="none" stroke="#000000" points="4910,-2020.5 4910,-2050.5 5233,-2050.5 5233,-2020.5 4910,-2020.5"/>
+<text text-anchor="start" x="4917" y="-2031.9" font-family="Arial" font-size="14.00" fill="#000000">algo_name </text>
+<text text-anchor="start" x="4990.136" y="-2031.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1990.5 4910,-2020.5 5233,-2020.5 5233,-1990.5 4910,-1990.5"/>
+<text text-anchor="start" x="4917" y="-2001.9" font-family="Arial" font-size="14.00" fill="#000000">algo_description_address </text>
+<text text-anchor="start" x="5080.3786" y="-2001.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1960.5 4910,-1990.5 5233,-1990.5 5233,-1960.5 4910,-1960.5"/>
+<text text-anchor="start" x="4917" y="-1971.9" font-family="Arial" font-size="14.00" fill="#000000">algo_description_checksum </text>
+<text text-anchor="start" x="5093.596" y="-1971.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1930.5 4910,-1960.5 5233,-1960.5 5233,-1930.5 4910,-1930.5"/>
+<text text-anchor="start" x="4917" y="-1941.9" font-family="Arial" font-size="14.00" fill="#000000">algo_algorithm_address </text>
+<text text-anchor="start" x="5070.2566" y="-1941.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(200)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1900.5 4910,-1930.5 5233,-1930.5 5233,-1900.5 4910,-1900.5"/>
+<text text-anchor="start" x="4917" y="-1911.9" font-family="Arial" font-size="14.00" fill="#000000">algo_algorithm_checksum </text>
+<text text-anchor="start" x="5083.474" y="-1911.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(64)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1870.5 4910,-1900.5 5233,-1900.5 5233,-1870.5 4910,-1870.5"/>
+<text text-anchor="start" x="4917" y="-1881.9" font-family="Arial" font-size="14.00" fill="#000000">algo_permissions </text>
+<text text-anchor="start" x="5029.7924" y="-1881.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1840.5 4910,-1870.5 5233,-1870.5 5233,-1840.5 4910,-1840.5"/>
+<text text-anchor="start" x="4917" y="-1851.9" font-family="Arial" font-size="14.00" fill="#000000">algo_owner </text>
+<text text-anchor="start" x="4993.2426" y="-1851.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1810.5 4910,-1840.5 5233,-1840.5 5233,-1810.5 4910,-1810.5"/>
+<text text-anchor="start" x="4917" y="-1821.9" font-family="Arial" font-size="14.00" fill="#000000">algo_creation_date </text>
+<text text-anchor="start" x="5039.9368" y="-1821.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1780.5 4910,-1810.5 5233,-1810.5 5233,-1780.5 4910,-1780.5"/>
+<text text-anchor="start" x="4917" y="-1791.9" font-family="Arial" font-size="14.00" fill="#000000">algo_metadata </text>
+<text text-anchor="start" x="5013.4824" y="-1791.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="4910,-1750.5 4910,-1780.5 5233,-1780.5 5233,-1750.5 4910,-1750.5"/>
+<text text-anchor="start" x="4917" y="-1761.9" font-family="Arial" font-size="14.00" fill="#000000">parent_task_keys </text>
+<text text-anchor="start" x="5030.5932" y="-1761.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+</g>
+<!-- public.expanded_compute_plans -->
+<g id="node32" class="node">
+<title>public.expanded_compute_plans</title>
+<polygon fill="#efefef" stroke="transparent" points="5337,-2320.5 5337,-2355.5 5661,-2355.5 5661,-2320.5 5337,-2320.5"/>
+<polygon fill="none" stroke="#000000" points="5337,-2320.5 5337,-2355.5 5661,-2355.5 5661,-2320.5 5337,-2320.5"/>
+<text text-anchor="start" x="5343.7264" y="-2333.3" font-family="Arial Bold" font-size="18.00" fill="#000000">public.expanded_compute_plans</text>
+<text text-anchor="start" x="5606.8234" y="-2333.3" font-family="Arial" font-size="14.00" fill="#000000"> </text>
+<text text-anchor="start" x="5610.714" y="-2333.3" font-family="Arial" font-size="14.00" fill="#666666">[VIEW]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2290.5 5337,-2320.5 5661,-2320.5 5661,-2290.5 5337,-2290.5"/>
+<text text-anchor="start" x="5344" y="-2301.9" font-family="Arial" font-size="14.00" fill="#000000">key </text>
+<text text-anchor="start" x="5369.6732" y="-2301.9" font-family="Arial" font-size="14.00" fill="#666666">[uuid]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2260.5 5337,-2290.5 5661,-2290.5 5661,-2260.5 5337,-2260.5"/>
+<text text-anchor="start" x="5344" y="-2271.9" font-family="Arial" font-size="14.00" fill="#000000">channel </text>
+<text text-anchor="start" x="5396.9102" y="-2271.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2230.5 5337,-2260.5 5661,-2260.5 5661,-2230.5 5337,-2230.5"/>
+<text text-anchor="start" x="5344" y="-2241.9" font-family="Arial" font-size="14.00" fill="#000000">owner </text>
+<text text-anchor="start" x="5386.0056" y="-2241.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2200.5 5337,-2230.5 5661,-2230.5 5661,-2200.5 5337,-2200.5"/>
+<text text-anchor="start" x="5344" y="-2211.9" font-family="Arial" font-size="14.00" fill="#000000">creation_date </text>
+<text text-anchor="start" x="5432.6998" y="-2211.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2170.5 5337,-2200.5 5661,-2200.5 5661,-2170.5 5337,-2170.5"/>
+<text text-anchor="start" x="5344" y="-2181.9" font-family="Arial" font-size="14.00" fill="#000000">cancelation_date </text>
+<text text-anchor="start" x="5453.711" y="-2181.9" font-family="Arial" font-size="14.00" fill="#666666">[timestamp with time zone]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2140.5 5337,-2170.5 5661,-2170.5 5661,-2140.5 5337,-2140.5"/>
+<text text-anchor="start" x="5344" y="-2151.9" font-family="Arial" font-size="14.00" fill="#000000">tag </text>
+<text text-anchor="start" x="5367.3464" y="-2151.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2110.5 5337,-2140.5 5661,-2140.5 5661,-2110.5 5337,-2110.5"/>
+<text text-anchor="start" x="5344" y="-2121.9" font-family="Arial" font-size="14.00" fill="#000000">name </text>
+<text text-anchor="start" x="5382.899" y="-2121.9" font-family="Arial" font-size="14.00" fill="#666666">[varchar(100)]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2080.5 5337,-2110.5 5661,-2110.5 5661,-2080.5 5337,-2080.5"/>
+<text text-anchor="start" x="5344" y="-2091.9" font-family="Arial" font-size="14.00" fill="#000000">metadata </text>
+<text text-anchor="start" x="5406.2454" y="-2091.9" font-family="Arial" font-size="14.00" fill="#666666">[jsonb]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2050.5 5337,-2080.5 5661,-2080.5 5661,-2050.5 5337,-2050.5"/>
+<text text-anchor="start" x="5344" y="-2061.9" font-family="Arial" font-size="14.00" fill="#000000">task_count </text>
+<text text-anchor="start" x="5415.5848" y="-2061.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
+<polygon fill="none" stroke="#000000" points="5337,-2020.5 5337,-2050.5 5661,-2050.5 5661,-2020.5 5337,-2020.5"/>
+<text text-anchor="start" x="5344" y="-2031.9" font-family="Arial" font-size="14.00" fill="#000000">waiting_count </text>
+<text text-anchor="start" x="5433.4698" y="-2031.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
+<polygon fill="none" stroke="#000000" points="5337,-1990.5 5337,-2020.5 5661,-2020.5 5661,-1990.5 5337,-1990.5"/>
+<text text-anchor="start" x="5344" y="-2001.9" font-family="Arial" font-size="14.00" fill="#000000">todo_count </text>
+<text text-anchor="start" x="5417.15" y="-2001.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
+<polygon fill="none" stroke="#000000" points="5337,-1960.5 5337,-1990.5 5661,-1990.5 5661,-1960.5 5337,-1960.5"/>
+<text text-anchor="start" x="5344" y="-1971.9" font-family="Arial" font-size="14.00" fill="#000000">doing_count </text>
+<text text-anchor="start" x="5424.1486" y="-1971.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
+<polygon fill="none" stroke="#000000" points="5337,-1930.5 5337,-1960.5 5661,-1960.5 5661,-1930.5 5337,-1930.5"/>
+<text text-anchor="start" x="5344" y="-1941.9" font-family="Arial" font-size="14.00" fill="#000000">canceled_count </text>
+<text text-anchor="start" x="5445.9312" y="-1941.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
+<polygon fill="none" stroke="#000000" points="5337,-1900.5 5337,-1930.5 5661,-1930.5 5661,-1900.5 5337,-1900.5"/>
+<text text-anchor="start" x="5344" y="-1911.9" font-family="Arial" font-size="14.00" fill="#000000">failed_count </text>
+<text text-anchor="start" x="5423.3632" y="-1911.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
+<polygon fill="none" stroke="#000000" points="5337,-1870.5 5337,-1900.5 5661,-1900.5 5661,-1870.5 5337,-1870.5"/>
+<text text-anchor="start" x="5344" y="-1881.9" font-family="Arial" font-size="14.00" fill="#000000">done_count </text>
+<text text-anchor="start" x="5421.042" y="-1881.9" font-family="Arial" font-size="14.00" fill="#666666">[bigint]</text>
 </g>
 </g>
 </svg>

--- a/e2e/client/client.go
+++ b/e2e/client/client.go
@@ -422,9 +422,8 @@ func (c *TestClient) DisableOutput(taskRef string, identifier string) {
 
 func (c *TestClient) RegisterComputePlan(o *ComputePlanOptions) *asset.ComputePlan {
 	newCp := &asset.NewComputePlan{
-		Key:                      c.ks.GetKey(o.KeyRef),
-		Name:                     "Compute plan test",
-		DeleteIntermediaryModels: o.DeleteIntermediaryModels,
+		Key:  c.ks.GetKey(o.KeyRef),
+		Name: "Compute plan test",
 	}
 	c.logger.Debug().Interface("plan", newCp).Msg("registering compute plan")
 	plan, err := c.computePlanService.RegisterPlan(c.ctx, newCp)

--- a/e2e/client/option.go
+++ b/e2e/client/option.go
@@ -542,18 +542,12 @@ func (o *AlgoOptions) WithCategory(category asset.AlgoCategory) *AlgoOptions {
 
 func DefaultComputePlanOptions() *ComputePlanOptions {
 	return &ComputePlanOptions{
-		KeyRef:                   DefaultPlanRef,
-		DeleteIntermediaryModels: false,
+		KeyRef: DefaultPlanRef,
 	}
 }
 
 func (o *ComputePlanOptions) WithKeyRef(ref string) *ComputePlanOptions {
 	o.KeyRef = ref
-	return o
-}
-
-func (o *ComputePlanOptions) WithDeleteIntermediaryModels(flag bool) *ComputePlanOptions {
-	o.DeleteIntermediaryModels = flag
 	return o
 }
 

--- a/e2e/client/option.go
+++ b/e2e/client/option.go
@@ -9,8 +9,7 @@ import (
 )
 
 type ComputePlanOptions struct {
-	KeyRef                   string
-	DeleteIntermediaryModels bool
+	KeyRef string
 }
 
 type AlgoOptions struct {

--- a/lib/asset/computeplan.proto
+++ b/lib/asset/computeplan.proto
@@ -18,13 +18,12 @@ enum ComputePlanStatus {
 }
 
 message ComputePlan {
-  reserved 8, 9, 10, 11, 12, 3, 4;
-  reserved "waiting_count", "todo_count", "doing_count" ,"canceled_count", "failed_count", "done_count", "task_count";
+  reserved 8, 9, 10, 11, 12, 3, 4, 6;
+  reserved "waiting_count", "todo_count", "doing_count" ,"canceled_count", "failed_count", "done_count", "task_count", "delete_intermediary_models";
 
   string key = 1;
   string owner = 2;
   ComputePlanStatus status = 5; // Dynamic data, not persisted and set on query
-  bool delete_intermediary_models = 6;
   google.protobuf.Timestamp creation_date = 7;
   string tag = 16;
   string name = 19;

--- a/lib/asset/computeplan.proto
+++ b/lib/asset/computeplan.proto
@@ -32,11 +32,12 @@ message ComputePlan {
 }
 
 message NewComputePlan {
+  reserved 18;
+  reserved "delete_intermediary_models";
   string key = 1;
   string tag = 16;
   string name = 19;
   map<string, string> metadata = 17;
-  bool delete_intermediary_models = 18;
 }
 
 message GetComputePlanParam {

--- a/lib/service/computeplan.go
+++ b/lib/service/computeplan.go
@@ -15,7 +15,6 @@ type ComputePlanAPI interface {
 	QueryPlans(p *common.Pagination, filter *asset.PlanQueryFilter) ([]*asset.ComputePlan, common.PaginationToken, error)
 	ApplyPlanAction(key string, action asset.ComputePlanAction, requester string) error
 	UpdatePlan(computePlan *asset.UpdateComputePlanParam, requester string) error
-	canDeleteModels(key string) (bool, error)
 	computePlanExists(key string) (bool, error)
 }
 
@@ -59,14 +58,13 @@ func (s *ComputePlanService) RegisterPlan(input *asset.NewComputePlan, owner str
 	}
 
 	plan := &asset.ComputePlan{
-		Key:                      input.Key,
-		Owner:                    owner,
-		Tag:                      input.Tag,
-		Name:                     input.Name,
-		Metadata:                 input.Metadata,
-		DeleteIntermediaryModels: input.DeleteIntermediaryModels,
-		CreationDate:             timestamppb.New(s.GetTimeService().GetTransactionTime()),
-		Status:                   asset.ComputePlanStatus_PLAN_STATUS_EMPTY,
+		Key:          input.Key,
+		Owner:        owner,
+		Tag:          input.Tag,
+		Name:         input.Name,
+		Metadata:     input.Metadata,
+		CreationDate: timestamppb.New(s.GetTimeService().GetTransactionTime()),
+		Status:       asset.ComputePlanStatus_PLAN_STATUS_EMPTY,
 	}
 
 	err = s.GetComputePlanDBAL().AddComputePlan(plan)
@@ -173,16 +171,6 @@ func (s *ComputePlanService) cancelPlan(plan *asset.ComputePlan) error {
 	}
 
 	return s.GetEventService().RegisterEvents(event)
-}
-
-// canDeleteModels returns true if the compute plan allows intermediary models deletion.
-func (s *ComputePlanService) canDeleteModels(key string) (bool, error) {
-	plan, err := s.GetComputePlanDBAL().GetRawComputePlan(key)
-	if err != nil {
-		return false, err
-	}
-
-	return plan.DeleteIntermediaryModels, nil
 }
 
 func (s *ComputePlanService) computePlanExists(key string) (bool, error) {

--- a/lib/service/computeplan_test.go
+++ b/lib/service/computeplan_test.go
@@ -128,29 +128,6 @@ func TestCancelPlan(t *testing.T) {
 	es.AssertExpectations(t)
 }
 
-func TestComputePlanAllowIntermediaryModelDeletion(t *testing.T) {
-	dbal := new(persistence.MockDBAL)
-	provider := newMockedProvider()
-
-	provider.On("GetComputePlanDBAL").Return(dbal)
-
-	service := NewComputePlanService(provider)
-
-	cp := &asset.ComputePlan{
-		Key:                      "uuid",
-		DeleteIntermediaryModels: true,
-	}
-
-	dbal.On("GetRawComputePlan", "uuid").Once().Return(cp, nil)
-
-	canDelete, err := service.canDeleteModels("uuid")
-	assert.NoError(t, err)
-
-	assert.True(t, canDelete)
-
-	dbal.AssertExpectations(t)
-}
-
 func TestQueryPlans(t *testing.T) {
 	dbal := new(persistence.MockDBAL)
 	provider := newMockedProvider()

--- a/server/standalone/dbal/computeplan_test.go
+++ b/server/standalone/dbal/computeplan_test.go
@@ -18,10 +18,10 @@ func TestGetComputePlan(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	rows := pgxmock.NewRows([]string{"key", "owner", "delete_intermediary_models", "creation_date", "cancelation_date", "tag", "name", "metadata", "task_count", "waiting_count", "todo_count", "doing_count", "canceled_count", "failed_count", "done_count"}).
-		AddRow("uuid", "owner", false, time.Now(), nil, "", "My compute plan", map[string]string{}, uint32(21), uint32(1), uint32(2), uint32(3), uint32(4), uint32(5), uint32(6))
+	rows := pgxmock.NewRows([]string{"key", "owner", "creation_date", "cancelation_date", "tag", "name", "metadata", "task_count", "waiting_count", "todo_count", "doing_count", "canceled_count", "failed_count", "done_count"}).
+		AddRow("uuid", "owner", time.Now(), nil, "", "My compute plan", map[string]string{}, uint32(21), uint32(1), uint32(2), uint32(3), uint32(4), uint32(5), uint32(6))
 
-	mock.ExpectQuery(`SELECT key, owner, delete_intermediary_models, creation_date, cancelation_date, tag, name, metadata, task_count, waiting_count, todo_count, doing_count, canceled_count, failed_count, done_count`).
+	mock.ExpectQuery(`SELECT key, owner, creation_date, cancelation_date, tag, name, metadata, task_count, waiting_count, todo_count, doing_count, canceled_count, failed_count, done_count`).
 		WithArgs(testChannel, "uuid").
 		WillReturnRows(rows)
 
@@ -44,10 +44,10 @@ func TestGetRawComputePlan(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	rows := pgxmock.NewRows([]string{"key", "owner", "delete_intermediary_models", "creation_date", "cancelation_date", "tag", "name", "metadata"}).
-		AddRow("uuid", "owner", false, time.Now(), nil, "", "My compute plan", map[string]string{})
+	rows := pgxmock.NewRows([]string{"key", "owner", "creation_date", "cancelation_date", "tag", "name", "metadata"}).
+		AddRow("uuid", "owner", time.Now(), nil, "", "My compute plan", map[string]string{})
 
-	mock.ExpectQuery(`SELECT key, owner, delete_intermediary_models, creation_date, cancelation_date, tag, name, metadata FROM compute_plans`).
+	mock.ExpectQuery(`SELECT key, owner, creation_date, cancelation_date, tag, name, metadata FROM compute_plans`).
 		WithArgs(testChannel, "uuid").
 		WillReturnRows(rows)
 
@@ -70,8 +70,8 @@ func TestQueryComputePlans(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	rows := pgxmock.NewRows([]string{"key", "owner", "delete_intermediary_models", "creation_date", "cancelation_date", "tag", "name", "metadata", "task_count", "waiting_count", "todo_count", "doing_count", "canceled_count", "failed_count", "done_count"}).
-		AddRow("uuid", "owner", false, time.Now(), nil, "", "My compute plan", map[string]string{}, uint32(21), uint32(1), uint32(2), uint32(3), uint32(4), uint32(5), uint32(6))
+	rows := pgxmock.NewRows([]string{"key", "owner", "creation_date", "cancelation_date", "tag", "name", "metadata", "task_count", "waiting_count", "todo_count", "doing_count", "canceled_count", "failed_count", "done_count"}).
+		AddRow("uuid", "owner", time.Now(), nil, "", "My compute plan", map[string]string{}, uint32(21), uint32(1), uint32(2), uint32(3), uint32(4), uint32(5), uint32(6))
 
 	mock.ExpectQuery(`SELECT key,.* FROM expanded_compute_plans .* ORDER BY creation_date ASC, key ASC`).
 		WithArgs(testChannel, "owner").
@@ -100,7 +100,7 @@ func TestQueryComputePlansNilFilter(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	rows := pgxmock.NewRows([]string{"key", "owner", "delete_intermediary_models", "creation_date", "cancelation_date", "tag", "name", "metadata", "task_count", "waiting_count", "todo_count", "doing_count", "canceled_count", "failed_count", "done_count"})
+	rows := pgxmock.NewRows([]string{"key", "owner", "creation_date", "cancelation_date", "tag", "name", "metadata", "task_count", "waiting_count", "todo_count", "doing_count", "canceled_count", "failed_count", "done_count"})
 
 	mock.ExpectQuery(`SELECT key,.* FROM expanded_compute_plans .* ORDER BY creation_date ASC, key`).
 		WithArgs(testChannel).

--- a/server/standalone/migration/000044_remove_delete_intermediary_model.down.sql
+++ b/server/standalone/migration/000044_remove_delete_intermediary_model.down.sql
@@ -1,5 +1,5 @@
 ALTER TABLE compute_plans
-ADD COLUMN IF NOT EXISTS delete_intermediary_models bool
+ADD COLUMN IF NOT EXISTS delete_intermediary_models bool;
 
 ALTER TABLE compute_plans
 ALTER COLUMN delete_intermediary_models SET DEFAULT false;

--- a/server/standalone/migration/000044_remove_delete_intermediary_model.down.sql
+++ b/server/standalone/migration/000044_remove_delete_intermediary_model.down.sql
@@ -1,8 +1,5 @@
 ALTER TABLE compute_plans
-ADD COLUMN IF NOT EXISTS delete_intermediary_models bool;
-
-ALTER TABLE compute_plans
-ALTER COLUMN delete_intermediary_models SET DEFAULT false;
+ADD COLUMN IF NOT EXISTS delete_intermediary_models bool DEFAULT false;
 
 ALTER TABLE compute_plans
 ALTER COLUMN delete_intermediary_models SET NOT NULL; 

--- a/server/standalone/migration/000044_remove_delete_intermediary_model.down.sql
+++ b/server/standalone/migration/000044_remove_delete_intermediary_model.down.sql
@@ -1,0 +1,31 @@
+ALTER TABLE compute_plans
+ADD COLUMN IF NOT EXISTS delete_intermediary_models bool
+
+ALTER TABLE compute_plans
+ALTER COLUMN delete_intermediary_models SET DEFAULT false;
+
+ALTER TABLE compute_plans
+ALTER COLUMN delete_intermediary_models SET NOT NULL; 
+
+DROP VIEW IF EXISTS expanded_compute_plans;
+
+CREATE VIEW expanded_compute_plans AS
+SELECT 	cp.key                                               AS key,
+	cp.channel                                           AS channel,
+        cp.owner                                             AS owner,
+	cp.delete_intermediary_models                        AS delete_intermediary_models,
+        cp.creation_date                                     AS creation_date,
+        cp.cancelation_date                                  AS cancelation_date,
+        cp.tag                                               AS tag,
+        cp.name                                              AS name,
+        cp.metadata                                          AS metadata,
+        COUNT(1)                                             AS task_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_WAITING')  AS waiting_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_TODO')     AS todo_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_DOING')    AS doing_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_CANCELED') AS canceled_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_FAILED')   AS failed_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_DONE')     AS done_count
+FROM compute_plans cp
+LEFT JOIN compute_tasks t ON cp.key = t.compute_plan_key
+GROUP BY cp.key;

--- a/server/standalone/migration/000044_remove_delete_intermediary_model.up.sql
+++ b/server/standalone/migration/000044_remove_delete_intermediary_model.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE compute_plans
+DROP COLUMN IF EXISTS delete_intermediary_models;

--- a/server/standalone/migration/000044_remove_delete_intermediary_model.up.sql
+++ b/server/standalone/migration/000044_remove_delete_intermediary_model.up.sql
@@ -1,2 +1,24 @@
+DROP VIEW IF EXISTS expanded_compute_plans;
+
+CREATE VIEW expanded_compute_plans AS
+SELECT 	cp.key                                               AS key,
+	cp.channel                                           AS channel,
+        cp.owner                                             AS owner,
+        cp.creation_date                                     AS creation_date,
+        cp.cancelation_date                                  AS cancelation_date,
+        cp.tag                                               AS tag,
+        cp.name                                              AS name,
+        cp.metadata                                          AS metadata,
+        COUNT(1)                                             AS task_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_WAITING')  AS waiting_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_TODO')     AS todo_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_DOING')    AS doing_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_CANCELED') AS canceled_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_FAILED')   AS failed_count,
+        COUNT(1) FILTER (WHERE t.status = 'STATUS_DONE')     AS done_count
+FROM compute_plans cp
+LEFT JOIN compute_tasks t ON cp.key = t.compute_plan_key
+GROUP BY cp.key;
+
 ALTER TABLE compute_plans
 DROP COLUMN IF EXISTS delete_intermediary_models;


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

Remove the `delete_intermediary_models` flag from the ComputePlan and NewComputePlan messages. 

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
e2e tests.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
