### PR TITLE
feat: prevent use of '__' in asset metadata keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 **WARNING**: Some migrations in this version are destructive once applied you will not be able to restore algo categories.
 
+### Added
+
+- Prevent use of `__` in asset metadata keys
+
 ### Changed
+
 - (BREAKING) Algo.category: do not rely on categories anymore, all algo categories will be returned as UNKNOWN
 - NewAlgo.category: No category is expected
 

--- a/lib/asset/algo_validation_test.go
+++ b/lib/asset/algo_validation_test.go
@@ -60,7 +60,15 @@ func TestAlgoValidate(t *testing.T) {
 			Description:    validAddressable,
 			NewPermissions: validPerms,
 		}, true},
-
+		"invalid_metadata": {&NewAlgo{
+			Key:            "08680966-97ae-4573-8b2d-6c4db2b3c532",
+			Name:           "Test algo",
+			Category:       AlgoCategory_ALGO_SIMPLE,
+			Metadata:       map[string]string{"wrong__key": "value"},
+			Algorithm:      validAddressable,
+			Description:    validAddressable,
+			NewPermissions: validPerms,
+		}, false},
 		"invalid_input_kind": {&NewAlgo{
 			Key:            "08680966-97ae-4573-8b2d-6c4db2b3c532",
 			Name:           "Test algo",

--- a/lib/asset/common_validation.go
+++ b/lib/asset/common_validation.go
@@ -2,6 +2,7 @@ package asset
 
 import (
 	"fmt"
+	"strings"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
@@ -40,6 +41,9 @@ func validateMetadata(input interface{}) error {
 		}
 		if len(v) > 100 {
 			return errors.NewInvalidAsset(fmt.Sprintf("metadata value for key %q is too long", k))
+		}
+		if strings.Contains(k, "__") {
+			return errors.NewInvalidAsset(fmt.Sprintf("'__' cannot be used in a metadata key, please use simple underscore instead for key %q", k))
 		}
 	}
 

--- a/lib/asset/common_validation_test.go
+++ b/lib/asset/common_validation_test.go
@@ -34,3 +34,11 @@ func TestPermissionsValidation(t *testing.T) {
 	assert.Error(t, emptyPermissions.Validate(), "empty object is invalid")
 	assert.NoError(t, complete.Validate())
 }
+
+func TestMetadataValidation(t *testing.T) {
+	invalidMetadata := map[string]string{"not__allowed": "indeed"}
+	validMetadata := map[string]string{"allowed": "indeed"}
+
+	assert.Error(t, validateMetadata(invalidMetadata), "'__' cannot be used in a metadata key, please use simple underscore instead for key \"not__allowed\"")
+	assert.NoError(t, validateMetadata(validMetadata))
+}

--- a/lib/asset/computeplan_validation_test.go
+++ b/lib/asset/computeplan_validation_test.go
@@ -21,6 +21,11 @@ func TestValidateNewComputePlan(t *testing.T) {
 			Key:  "not36chars",
 			Name: "The name of my compute plan",
 		}, false},
+		"invalidMetadata": {&NewComputePlan{
+			Key:      "08680966-97ae-4573-8b2d-6c4db2b3c532",
+			Name:     "The name of my compute plan",
+			Metadata: map[string]string{"wrong__key": "value"},
+		}, false},
 		"valid": {&NewComputePlan{
 			Key:  "08680966-97ae-4573-8b2d-6c4db2b3c532",
 			Name: "The name of my compute plan",

--- a/lib/asset/computetask_validation_test.go
+++ b/lib/asset/computetask_validation_test.go
@@ -230,6 +230,37 @@ func TestNewComputeTaskValidation(t *testing.T) {
 			},
 		},
 	}
+	invalidMetadata := &NewComputeTask{
+		Key:            "867852b4-8419-4d52-8862-d5db823095be",
+		Category:       ComputeTaskCategory_TASK_TRAIN,
+		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
+		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
+		Metadata:       map[string]string{"wrong__key": "value"},
+		Data: &NewComputeTask_Train{
+			Train: &NewTrainTaskData{
+				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
+				DataSampleKeys: []string{"85e39014-ae2e-4fa4-b05b-4437076a4fa7", "8a90a6e3-2e7e-4c9d-9ed3-47b99942d0a8"},
+			},
+		},
+		Inputs: []*ComputeTaskInput{
+			{
+				Identifier: "model",
+				Ref: &ComputeTaskInput_AssetKey{
+					AssetKey: "867852b4-8419-4d52-8862-d5db823095be",
+				},
+			},
+			{
+				Identifier: "model2",
+				Ref: &ComputeTaskInput_ParentTaskOutput{
+					ParentTaskOutput: &ParentTaskOutputRef{
+						ParentTaskKey:    "867852b4-8419-4d52-8862-d5db823095be",
+						OutputIdentifier: "model",
+					},
+				},
+			},
+		},
+		Outputs: validOutputs,
+	}
 
 	cases := map[string]struct {
 		valid   bool
@@ -247,6 +278,7 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		"invalid intput task output key":        {valid: false, newTask: invalidInputTaskOutputKey},
 		"missing input task output identifier":  {valid: false, newTask: missingInputTaskOutputIdentifier},
 		"invalid output permissions identifier": {valid: false, newTask: invalidOutputPermissionsIdentifier},
+		"invalidMetadata":                       {valid: false, newTask: invalidMetadata},
 	}
 
 	for name, c := range cases {

--- a/lib/asset/datamanager_validation_test.go
+++ b/lib/asset/datamanager_validation_test.go
@@ -38,6 +38,16 @@ func TestDataManagerValidate(t *testing.T) {
 			Type:           "test",
 			LogsPermission: validPermissions,
 		}, false},
+		"invalidMetadata": {&NewDataManager{
+			Key:            "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
+			Name:           "Test Data Manager",
+			Metadata:       map[string]string{"wrong__key": "value"},
+			NewPermissions: validPermissions,
+			Description:    validAddressable,
+			Opener:         validAddressable,
+			Type:           "test",
+			LogsPermission: validPermissions,
+		}, false},
 		"valid": {&NewDataManager{
 			Key:            "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
 			Name:           "Test Data Manager",


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
Related [asana task](https://app.asana.com/0/1200346939311555/1202768358328705)

<!-- Please include a summary of your changes. -->

Bug raised by Tanguy
> There is a bug in the front with the filters on metadata. Maybe it’s because I’m using metadata with underscore and point

In Django orm, double underscores are interpreted as a way to navigate db relations. When filtering on a metadata key string containing `__` like `var__a` for instance, the backend will try to filter on a key `[var, a]`, resulting in wrong or no filtering.
While this does not trigger any error in the backend, this undermines the user trust in the filters, possibly leading to the user not using the filtering feature at all (even on other fields than metadata). 

To be able to properly filter on all metadata, we should not allow user to add metadata keys containing '__'. 
As discussed with @almoisson and Tanguy, from a user perspective it's more acceptable to not be able to use `__` in a metadata key than to loose filtering feature.

The orchestrator now returns a `ErrInvalidAsset` error with message `"__" cannot be used in a metadata key, please use simple underscore instead` when trying to register an asset with wrong metadata key.

### Companion PRs

- https://github.com/Substra/substra-backend/pull/468
- https://github.com/Substra/substra/pull/289
- https://github.com/Substra/substra-tests/pull/212

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
Full e2e tests ran on Substra standalone instance locally

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
