### PR TITLE
feat: check for the external hostname in the health probe

### DIFF
--- a/charts/orchestrator/CHANGELOG.md
+++ b/charts/orchestrator/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.4.5] - 2022-09-26
+
+### Changed
+- health probe now chech liveness and readiness with `ingress.hostname` instead of an internal service hostname.
+
 ## [7.4.4] - 2022-09-26
 
 ### Changed

--- a/charts/orchestrator/CHANGELOG.md
+++ b/charts/orchestrator/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.4.5] - 2022-09-26
 
 ### Changed
-- health probe now chech liveness and readiness with `ingress.hostname` instead of an internal service hostname.
+- health probe now chech liveness and readiness with `ingress.hostname` instead of an internal service hostname when `ingress.hostname` is defined.
 
 ## [7.4.4] - 2022-09-26
 

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -3,7 +3,7 @@ name: orchestrator
 description: substra orchestration
 
 type: application
-version: 7.4.4
+version: 7.4.5
 appVersion: 0.28.0
 kubeVersion: ">= 1.19.0-0"
 icon: https://avatars.githubusercontent.com/u/84009910?s=400

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -49,7 +49,7 @@ helm install my-release charts/orchestrator --set 'channels[0].name=mychannel' -
 | `ingress.enabled`                          | Enable ingress for Orchestrator service                                       | `false`                  |
 | `ingress.ingressClassName`                 | Ingress class name                                                            | `nil`                    |
 | `ingress.path`                             | path of the deault host                                                       | `/`                      |
-| `ingress.hostname`                         | hostname of the default host                                                  | `orchestrator.org-1.com` |
+| `ingress.hostname`                         | hostname of the default host                                                  | `""`                     |
 | `ingress.extraPaths`                       | The list of extra paths to be created for the default host                    | `[]`                     |
 | `ingress.pathType`                         | Ingress path type                                                             | `ImplementationSpecific` |
 | `ingress.extraHosts`                       | The list of additional hostnames to be covered with this ingress record       | `[]`                     |

--- a/charts/orchestrator/templates/deployment.yaml
+++ b/charts/orchestrator/templates/deployment.yaml
@@ -45,15 +45,19 @@ spec:
             exec:
               command:
                 - "/bin/grpc_health_probe"
+                - "-v"
                 - "-addr=:9000"
-               {{- if $.Values.orchestrator.tls.enabled }}
+                {{- if .Values.orchestrator.tls.enabled }}
                 - "-tls"
                 - "-tls-ca-cert=/var/orchestrator/tls/server/cacert/ca.crt"
+                {{- if .Values.ingress.hostname }}
+                - "-tls-server-name={{ .Values.ingress.hostname}}" 
+                {{- else }}
                 - "-tls-server-name={{ include "orchestrator.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
-                {{- if $.Values.orchestrator.tls.mtls.enabled }}
+                {{- end }}
+                {{- if .Values.orchestrator.tls.mtls.enabled }}
                 - "-tls-client-key=/var/orchestrator/tls/server/pair/tls.key"
                 - "-tls-client-cert=/var/orchestrator/tls/server/pair/tls.crt"
-                - "-v"
                 {{- end }}
                 {{- end }}
             periodSeconds: 10
@@ -62,15 +66,19 @@ spec:
             exec:
               command:
                 - "/bin/grpc_health_probe"
+                - "-v"
                 - "-addr=:9000"
                {{- if $.Values.orchestrator.tls.enabled }}
                 - "-tls"
                 - "-tls-ca-cert=/var/orchestrator/tls/server/cacert/ca.crt"
+                {{- if .Values.ingress.hostname }}
+                - "-tls-server-name={{ .Values.ingress.hostname}}" 
+                {{- else }}
                 - "-tls-server-name={{ include "orchestrator.server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+                {{- end }}
                 {{- if $.Values.orchestrator.tls.mtls.enabled }}
                 - "-tls-client-key=/var/orchestrator/tls/server/pair/tls.key"
                 - "-tls-client-cert=/var/orchestrator/tls/server/pair/tls.crt"
-                - "-v"
                 {{- end }}
                 {{- end }}
             periodSeconds: 10

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -101,7 +101,7 @@ ingress:
   ##
   path: /
   ## @param ingress.hostname hostname of the default host
-  hostname: orchestrator.org-1.com
+  hostname: ""
   ## @param ingress.extraPaths The list of extra paths to be created for the default host
   ## e.g:
   ## extraPaths:


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->
When running the orchestrator with TLS enabled in standalone mode the user needed to include the internal hostname `my-orchestrartor.orchestrator.svc.cluster.local` in his certificate to make the startup probe pass.
This is not ideal as you might not want to add this internal hostname in your public certificates.

With this change when `ingress.hostname` is set we use this server name to check the validity of the certificate.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

Tested locally by deploying with Skaffold.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
