### PR TITLE
docs: fix mention of secret where it should be configmap

### DIFF
--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -118,7 +118,7 @@ helm install my-release charts/orchestrator --set 'channels[0].name=mychannel' -
 | `orchestrator.tls.secrets.pair`                  | A secret containing the server TLS cert/key pair `tls.crt` and `tls.key`                                                                                                 | `orchestrator-tls-server-pair` |
 | `orchestrator.tls.cacert`                        | A ConfigMap containing the server TLS CA cert `cat.crt`                                                                                                                  | `orchestrator-tls-cacert`      |
 | `orchestrator.tls.mtls.enabled`                  | If true, enable TLS client verification                                                                                                                                  | `false`                        |
-| `orchestrator.tls.mtls.clientCACerts`            | A map whose keys are names of the CAs, and values are a list of secrets containing CA certificates                                                                       | `{}`                           |
+| `orchestrator.tls.mtls.clientCACerts`            | A map whose keys are names of the CAs, and values are a list of configmaps containing CA certificates                                                                    | `{}`                           |
 
 
 ### Channels settings

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -326,7 +326,7 @@ orchestrator:
       ## @param orchestrator.tls.mtls.enabled If true, enable TLS client verification
       ##
       enabled: false
-      ## @param orchestrator.tls.mtls.clientCACerts A map whose keys are names of the CAs, and values are a list of secrets containing CA certificates
+      ## @param orchestrator.tls.mtls.clientCACerts A map whose keys are names of the CAs, and values are a list of configmaps containing CA certificates
       ## Here you should provide the orchestrator clients ca certs if you are using a private certificate authority
       ## e.g:
       ## orchestrator-ca:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We used to mention secret in a location where we expected a configmap.

see here for the matching code: https://github.com/Substra/orchestrator/blob/ed12733031da57fd55e4bdf72f3ab8e0991642ad/charts/orchestrator/templates/deployment.yaml#L171-L181
