### PR TITLE
feat: allow unknown task category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- TASK_UNKNOWN is a valid category
+
 ## [0.29.0] - 2022-10-03
 
 ### Added

--- a/lib/asset/computetask_validation.go
+++ b/lib/asset/computetask_validation.go
@@ -13,17 +13,21 @@ import (
 func (t *NewComputeTask) Validate() error {
 	baseTaskErr := validation.ValidateStruct(t,
 		validation.Field(&t.Key, validation.Required, is.UUID),
-		validation.Field(&t.Category, validation.Required, validation.In(ComputeTaskCategory_TASK_TRAIN, ComputeTaskCategory_TASK_COMPOSITE, ComputeTaskCategory_TASK_AGGREGATE, ComputeTaskCategory_TASK_TEST, ComputeTaskCategory_TASK_PREDICT)),
+		validation.Field(&t.Category, validation.In(ComputeTaskCategory_TASK_TRAIN, ComputeTaskCategory_TASK_COMPOSITE, ComputeTaskCategory_TASK_AGGREGATE, ComputeTaskCategory_TASK_TEST, ComputeTaskCategory_TASK_PREDICT, ComputeTaskCategory_TASK_UNKNOWN)),
 		validation.Field(&t.AlgoKey, validation.Required, is.UUID),
 		validation.Field(&t.ComputePlanKey, validation.Required, is.UUID),
 		validation.Field(&t.Metadata, validation.By(validateMetadata)),
-		validation.Field(&t.Data, validation.Required),
+		validation.Field(&t.Data, validation.Required.When(t.Category != ComputeTaskCategory_TASK_UNKNOWN)),
 		validation.Field(&t.Inputs, validation.By(validateTaskInputs)),
 		validation.Field(&t.Outputs, validation.By(validateTaskOutputs)),
 	)
 
 	if baseTaskErr != nil {
 		return baseTaskErr
+	}
+
+	if t.Category == ComputeTaskCategory_TASK_UNKNOWN {
+		return nil
 	}
 
 	switch d := t.Data.(type) {

--- a/lib/asset/computetask_validation_test.go
+++ b/lib/asset/computetask_validation_test.go
@@ -45,6 +45,19 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		},
 		Outputs: validOutputs,
 	}
+	invalidCategory := &NewComputeTask{
+		Key:            "867852b4-8419-4d52-8862-d5db823095be",
+		Category:       88,
+		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
+		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
+		Metadata:       map[string]string{"test": "indeed"},
+		Data: &NewComputeTask_Train{
+			Train: &NewTrainTaskData{
+				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
+				DataSampleKeys: []string{"85e39014-ae2e-4fa4-b05b-4437076a4fa7", "8a90a6e3-2e7e-4c9d-9ed3-47b99942d0a8"},
+			},
+		},
+	}
 	unknownCategory := &NewComputeTask{
 		Key:            "867852b4-8419-4d52-8862-d5db823095be",
 		Category:       ComputeTaskCategory_TASK_UNKNOWN,
@@ -230,6 +243,7 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		newTask *NewComputeTask
 	}{
 		"valid":                                 {valid: true, newTask: validTrainTask},
+		"invalid category":                      {valid: false, newTask: invalidCategory},
 		"unknown category":                      {valid: true, newTask: unknownCategory},
 		"missing algokey":                       {valid: false, newTask: missingAlgo},
 		"missing compute plan":                  {valid: false, newTask: missingComputePlan},

--- a/lib/asset/computetask_validation_test.go
+++ b/lib/asset/computetask_validation_test.go
@@ -45,18 +45,12 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		},
 		Outputs: validOutputs,
 	}
-	invalidCategory := &NewComputeTask{
+	unknownCategory := &NewComputeTask{
 		Key:            "867852b4-8419-4d52-8862-d5db823095be",
 		Category:       ComputeTaskCategory_TASK_UNKNOWN,
 		AlgoKey:        "867852b4-8419-4d52-8862-d5db823095be",
 		ComputePlanKey: "867852b4-8419-4d52-8862-d5db823095be",
 		Metadata:       map[string]string{"test": "indeed"},
-		Data: &NewComputeTask_Train{
-			Train: &NewTrainTaskData{
-				DataManagerKey: "2837f0b7-cb0e-4a98-9df2-68c116f65ad6",
-				DataSampleKeys: []string{"85e39014-ae2e-4fa4-b05b-4437076a4fa7", "8a90a6e3-2e7e-4c9d-9ed3-47b99942d0a8"},
-			},
-		},
 	}
 	missingAlgo := &NewComputeTask{
 		Key:            "867852b4-8419-4d52-8862-d5db823095be",
@@ -236,7 +230,7 @@ func TestNewComputeTaskValidation(t *testing.T) {
 		newTask *NewComputeTask
 	}{
 		"valid":                                 {valid: true, newTask: validTrainTask},
-		"invalid category":                      {valid: false, newTask: invalidCategory},
+		"unknown category":                      {valid: true, newTask: unknownCategory},
 		"missing algokey":                       {valid: false, newTask: missingAlgo},
 		"missing compute plan":                  {valid: false, newTask: missingComputePlan},
 		"missing train data":                    {valid: false, newTask: missingData},

--- a/lib/service/computetask_test.go
+++ b/lib/service/computetask_test.go
@@ -271,10 +271,14 @@ func TestRegisterTrainTask(t *testing.T) {
 	assert.NoError(t, err)
 
 	cps.AssertExpectations(t)
+	dms.AssertExpectations(t)
 	dbal.AssertExpectations(t)
 	provider.AssertExpectations(t)
 	es.AssertExpectations(t)
 	ts.AssertExpectations(t)
+	as.AssertExpectations(t)
+	os.AssertExpectations(t)
+	ps.AssertExpectations(t)
 }
 
 func TestRegisterCompositeTaskWithCompositeParents(t *testing.T) {
@@ -1959,6 +1963,75 @@ func TestGetTaskWorker(t *testing.T) {
 					assert.EqualError(t, err, c.err)
 				}
 				assert.Equal(t, c.worker, worker)
+			},
+		)
+	}
+}
+
+func TestGetLogsPermission(t *testing.T) {
+	dm := &asset.DataManager{
+		LogsPermission: &asset.Permission{
+			AuthorizedIds: []string{"test"},
+			Public:        false,
+		},
+	}
+
+	dms := new(MockDataManagerAPI)
+	os := new(MockOrganizationAPI)
+	os.On("GetAllOrganizations").Return([]*asset.Organization{
+		{Id: "org1"}, {Id: "org2"}, {Id: "org3"},
+	}, nil)
+
+	provider := newMockedProvider()
+	provider.On("GetDataManagerService").Return(dms)
+	provider.On("GetOrganizationService").Return(os)
+	provider.On("GetPermissionService").Return(NewPermissionService(provider))
+
+	dms.On("GetDataManager", "dmuuid").Return(dm, nil)
+
+	cases := map[string]struct {
+		owner       string
+		parentTasks []*asset.ComputeTask
+		taskInputs  []*asset.ComputeTaskInput
+		algoInputs  map[string]*asset.AlgoInput
+		outcome     *asset.Permission
+	}{
+		"with datamanager": {
+			taskInputs: []*asset.ComputeTaskInput{
+				{Identifier: "opener", Ref: &asset.ComputeTaskInput_AssetKey{AssetKey: "dmuuid"}},
+			},
+			algoInputs: map[string]*asset.AlgoInput{
+				"opener": {Kind: asset.AssetKind_ASSET_DATA_MANAGER},
+			},
+			outcome: dm.LogsPermission,
+		},
+		"with parents": {
+			owner: "test",
+			taskInputs: []*asset.ComputeTaskInput{
+				{Identifier: "model", Ref: &asset.ComputeTaskInput_ParentTaskOutput{ParentTaskOutput: &asset.ParentTaskOutputRef{ParentTaskKey: "parent1", OutputIdentifier: "model"}}},
+				{Identifier: "model", Ref: &asset.ComputeTaskInput_ParentTaskOutput{ParentTaskOutput: &asset.ParentTaskOutputRef{ParentTaskKey: "parent2", OutputIdentifier: "model"}}},
+			},
+			algoInputs: map[string]*asset.AlgoInput{
+				"model": {Kind: asset.AssetKind_ASSET_MODEL, Multiple: true},
+			},
+			parentTasks: []*asset.ComputeTask{
+				{Key: "parent1", LogsPermission: &asset.Permission{AuthorizedIds: []string{"org1"}}},
+				{Key: "parent2", LogsPermission: &asset.Permission{AuthorizedIds: []string{"org2"}}},
+			},
+			outcome: &asset.Permission{AuthorizedIds: []string{"test", "org1", "org2"}},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				service := NewComputeTaskService(provider)
+
+				permission, err := service.getLogsPermission(c.owner, c.parentTasks, c.taskInputs, c.algoInputs)
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, c.outcome.AuthorizedIds, permission.AuthorizedIds)
+				assert.Equal(t, c.outcome.Public, permission.Public)
 			},
 		)
 	}

--- a/server/standalone/migration/000050_allow_unknown_tasks.up.sql
+++ b/server/standalone/migration/000050_allow_unknown_tasks.up.sql
@@ -1,0 +1,3 @@
+INSERT INTO compute_task_categories(category)
+VALUES ('TASK_UNKNOWN')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
This is a temporary change to ease future removal of task categories. By allowing unknown tasks and bypassing the task-specific data field, consumers are already able to create truly generic tasks.

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
relying on CI

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
