### PR TITLE
feat: allow perf registration on any task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - TASK_UNKNOWN is a valid category
+- Allow registration of performances on any task category
 
 ## [0.29.0] - 2022-10-03
 

--- a/lib/service/performance.go
+++ b/lib/service/performance.go
@@ -58,10 +58,6 @@ func (s *PerformanceService) RegisterPerformance(newPerf *asset.NewPerformance, 
 		return nil, errors.NewPermissionDenied(fmt.Sprintf("only %q worker can register performance", task.Worker))
 	}
 
-	if task.Category != asset.ComputeTaskCategory_TASK_TEST {
-		return nil, errors.NewBadRequest("cannot register performance on non test task")
-	}
-
 	if task.Status != asset.ComputeTaskStatus_STATUS_DOING {
 		return nil, errors.NewBadRequest(fmt.Sprintf("cannot register performance for task with status %q", task.Status.String()))
 	}


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
Following #56 , we should allow perf registration on any task category (we enforce that the algo has a perf output anyway).

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
- unit tests

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
