### PR TITLE
fix: upgrade dependencies

### DIFF
--- a/docker/orchestrator-chaincode/dependencies.json
+++ b/docker/orchestrator-chaincode/dependencies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "git",
-    "version": "2.36.2-r0"
+    "version": "2.36.3-r0"
   },
   {
     "name": "make",
@@ -9,10 +9,10 @@
   },
   {
     "name": "protoc",
-    "version": "3.18.1-r2"
+    "version": "3.18.1-r3"
   },
   {
     "name": "protobuf-dev",
-    "version": "3.18.1-r2"
+    "version": "3.18.1-r3"
   }
 ]

--- a/docker/orchestrator-server/dependencies.json
+++ b/docker/orchestrator-server/dependencies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "git",
-    "version": "2.36.2-r0"
+    "version": "2.36.3-r0"
   },
   {
     "name": "make",
@@ -9,10 +9,10 @@
   },
   {
     "name": "protoc",
-    "version": "3.18.1-r2"
+    "version": "3.18.1-r3"
   },
   {
     "name": "protobuf-dev",
-    "version": "3.18.1-r2"
+    "version": "3.18.1-r3"
   }
 ]


### PR DESCRIPTION
## Description

Upgrade dependencies since Alpine doesn't keep old versions of packages in repos, leading to [docker build failure](https://github.com/Substra/orchestrator/actions/runs/3298943621)

## How has this been tested?

Images used not to build, now they do.

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
