### PR TITLE
chore: add FL squad as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
+# historic code owners
 * @AurelienGasser @mblottiere @thibowk
+# Owkin FL squad
+* @ThibaultFy @oleobal @Milouu @guilhem-barthes


### PR DESCRIPTION
This will allow the FL squad to approve boilerplate PRs such as dependency updates

I'm leaving Aurélien, Matthieu and Thibaud in expecting they will be removed later, since their expertise is still needed. But we could also remove them now since we can still ask for review.
