### PR TITLE
build: Set postgresql version

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -16,7 +16,7 @@ jobs:
   e2e:
     services:
       postgres:
-        image: postgres
+        image: postgres:14.6
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
## Description

The pg_dump version in e2e GitHub action does not work due to descrepancy between `pg_dump` client (version 14.6) and the `postgres` server (15)

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
