### PR TITLE
refactor: remove parent task key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 
-- field `parent_task_keys` in `ComputeTask`
-- view `expanded_compute_tasks`
+- field `parent_task_keys` in `ComputeTask` ([#112](https://github.com/Substra/orchestrator/pull/112))
+- view `expanded_compute_tasks` ([#112](https://github.com/Substra/orchestrator/pull/112))
 
 ## [0.31.0] - 2022-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]()
+
+## Removed
+
+- field `parent_task_keys` in `ComputeTask`
+- view `expanded_compute_tasks`
 
 ## [0.31.0] - 2022-12-19
 

--- a/chaincode/ledger/dbal.go
+++ b/chaincode/ledger/dbal.go
@@ -64,6 +64,7 @@ type storedAsset struct {
 // dbal indexes
 const computePlanTaskStatusIndex = "computePlan~computePlanKey~status~task"
 const computeTaskParentIndex = "computeTask~parentTask~key"
+const computeTaskChildIndex = "computeTask~childTask~key"
 const modelTaskKeyIndex = "model~taskKey~modelKey"
 const performanceIndex = "performance~taskKey~metricKey"
 const allOrganizationsIndex = "organizations~id"

--- a/chaincode/ledger/dbal_computetask.go
+++ b/chaincode/ledger/dbal_computetask.go
@@ -9,6 +9,7 @@ import (
 	"github.com/substra/orchestrator/lib/common"
 	orcerrors "github.com/substra/orchestrator/lib/errors"
 	"github.com/substra/orchestrator/lib/persistence"
+	"github.com/substra/orchestrator/lib/service"
 	"github.com/substra/orchestrator/utils"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -38,7 +39,7 @@ func (db *DB) addComputeTask(t *asset.ComputeTask) error {
 	if err != nil {
 		return err
 	}
-	for _, parentTask := range t.ParentTaskKeys {
+	for _, parentTask := range service.GetParentTaskKeys(t.Inputs) {
 		err = db.createIndex(computeTaskParentIndex, []string{asset.ComputeTaskKind, parentTask, t.Key})
 		if err != nil {
 			return err

--- a/chaincode/ledger/dbal_computetask.go
+++ b/chaincode/ledger/dbal_computetask.go
@@ -38,6 +38,12 @@ func (db *DB) addComputeTask(t *asset.ComputeTask) error {
 	if err != nil {
 		return err
 	}
+	for _, parentTask := range t.ParentTaskKeys {
+		err = db.createIndex(computeTaskParentIndex, []string{asset.ComputeTaskKind, parentTask, t.Key})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/chaincode/ledger/dbal_computetask.go
+++ b/chaincode/ledger/dbal_computetask.go
@@ -176,18 +176,18 @@ func (db *DB) GetComputeTaskChildren(key string) ([]*asset.ComputeTask, error) {
 	return tasks, nil
 }
 
-// GetComputeTaskChildren returns the children of the task identified by the given key
+// GetComputeTaskParents returns the children of the task identified by the given key
 func (db *DB) GetComputeTaskParents(key string) ([]*asset.ComputeTask, error) {
 	elementKeys, err := db.getIndexKeys(computeTaskChildIndex, []string{asset.ComputeTaskKind, key})
 	if err != nil {
 		return nil, err
 	}
 
-	db.logger.Debug().Int("numChildren", len(elementKeys)).Msg("GetComputeTaskParents")
+	db.logger.Debug().Int("numParents", len(elementKeys)).Msg("GetComputeTaskParents")
 
 	tasks := []*asset.ComputeTask{}
-	for _, childKey := range elementKeys {
-		task, err := db.GetComputeTask(childKey)
+	for _, parentKey := range elementKeys {
+		task, err := db.GetComputeTask(parentKey)
 		if err != nil {
 			return nil, err
 		}

--- a/chaincode/ledger/dbal_computetask.go
+++ b/chaincode/ledger/dbal_computetask.go
@@ -38,12 +38,6 @@ func (db *DB) addComputeTask(t *asset.ComputeTask) error {
 	if err != nil {
 		return err
 	}
-	for _, parentTask := range t.ParentTaskKeys {
-		err = db.createIndex(computeTaskParentIndex, []string{asset.ComputeTaskKind, parentTask, t.Key})
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/lib/asset/computetask.proto
+++ b/lib/asset/computetask.proto
@@ -56,15 +56,13 @@ message NewComputeTaskOutput {
 // ComputeTask is a computation step in a ComputePlan.
 // It was previously called XXXtuple: Traintuple, CompositeTraintuple, etc
 message ComputeTask {
-  reserved 3, 12, 13, 14, 15, 18;
-  reserved "algo", "data", "test", "train", "composite", "aggregate", "predict";
+  reserved 3, 6, 12, 13, 14, 15, 18;
+  reserved "algo", "data", "test", "train", "composite", "aggregate", "parent_task_keys", "predict";
 
   string key = 1;
   ComputeTaskCategory category = 2;
   string owner = 4;
   string compute_plan_key = 5;
-  // Keys of parent ComputeTasks
-  repeated string parent_task_keys = 6;
   int32 rank = 7;
   ComputeTaskStatus status = 8; // mutable
   string worker = 9;

--- a/lib/persistence/computetask_dbal.go
+++ b/lib/persistence/computetask_dbal.go
@@ -17,6 +17,7 @@ type ComputeTaskDBAL interface {
 	UpdateComputeTaskStatus(taskKey string, taskStatus asset.ComputeTaskStatus) error
 	QueryComputeTasks(p *common.Pagination, filter *asset.TaskQueryFilter) ([]*asset.ComputeTask, common.PaginationToken, error)
 	GetComputeTaskChildren(key string) ([]*asset.ComputeTask, error)
+	GetComputeTaskParents(key string) ([]*asset.ComputeTask, error)
 	// GetComputePlanTasks returns the tasks of the compute plan identified by the given key
 	GetComputePlanTasks(key string) ([]*asset.ComputeTask, error)
 	GetComputePlanTasksKeys(key string) ([]string, error)

--- a/lib/service/computetask_test.go
+++ b/lib/service/computetask_test.go
@@ -231,7 +231,6 @@ func TestRegisterTrainTask(t *testing.T) {
 		ComputePlanKey: newTrainTask.ComputePlanKey,
 		Metadata:       newTrainTask.Metadata,
 		Status:         asset.ComputeTaskStatus_STATUS_TODO,
-		ParentTaskKeys: []string{},
 		Worker:         dataManager.Owner,
 		Inputs:         newTrainTask.Inputs,
 		CreationDate:   timestamppb.New(time.Unix(1337, 0)),
@@ -440,7 +439,6 @@ func TestRegisterCompositeTaskWithCompositeParents(t *testing.T) {
 		ComputePlanKey: newTask.ComputePlanKey,
 		Metadata:       newTask.Metadata,
 		Status:         asset.ComputeTaskStatus_STATUS_WAITING,
-		ParentTaskKeys: []string{parent1.Key, parent2.Key},
 		Worker:         dataManager.Owner,
 		Rank:           1,
 		CreationDate:   timestamppb.New(time.Unix(1337, 0)),
@@ -1654,7 +1652,7 @@ func TestGetParentTaskKeys(t *testing.T) {
 		t.Run(
 			fmt.Sprintf("parent task keys from inputs case %d", i),
 			func(t *testing.T) {
-				assert.Equal(t, c.keys, getParentTaskKeys(c.inputs))
+				assert.Equal(t, c.keys, GetParentTaskKeys(c.inputs))
 			},
 		)
 	}

--- a/lib/service/computetaskstate.go
+++ b/lib/service/computetaskstate.go
@@ -184,7 +184,7 @@ func (s *ComputeTaskService) propagateDone(triggeringParent, child *asset.Comput
 	}
 
 	// loop over parent, only change status if all parents are DONE
-	for _, parentKey := range child.ParentTaskKeys {
+	for _, parentKey := range GetParentTaskKeys(child.Inputs) {
 		if parentKey == triggeringParent.Key {
 			// We already know this one is DONE
 			continue

--- a/lib/service/computetaskstate.go
+++ b/lib/service/computetaskstate.go
@@ -183,17 +183,12 @@ func (s *ComputeTaskService) propagateDone(triggeringParent, child *asset.Comput
 		return nil
 	}
 
-	// loop over parent, only change status if all parents are DONE
-	for _, parentKey := range GetParentTaskKeys(child.Inputs) {
-		if parentKey == triggeringParent.Key {
-			// We already know this one is DONE
-			continue
-		}
-		parent, err := s.GetComputeTaskDBAL().GetComputeTask(parentKey)
-		if err != nil {
-			return err
-		}
+	parents, err := s.GetComputeTaskDBAL().GetComputeTaskParents(child.Key)
+	if err != nil {
+		return err
+	}
 
+	for _, parent := range parents {
 		if parent.Status != asset.ComputeTaskStatus_STATUS_DONE {
 			logger.Debug().
 				Str("parent", parent.Key).
@@ -204,7 +199,7 @@ func (s *ComputeTaskService) propagateDone(triggeringParent, child *asset.Comput
 			return nil
 		}
 	}
-	err := s.applyTaskAction(child, transitionTodo, fmt.Sprintf("Last parent task %s done", triggeringParent.Key))
+	err = s.applyTaskAction(child, transitionTodo, fmt.Sprintf("Last parent task %s done", triggeringParent.Key))
 	if err != nil {
 		return err
 	}

--- a/lib/service/computetaskstate_test.go
+++ b/lib/service/computetaskstate_test.go
@@ -194,6 +194,9 @@ func TestCascadeStatusDone(t *testing.T) {
 		Worker: "worker",
 	}
 	// Check for children to be updated
+	dbal.On("GetComputeTaskParents", "child").Return([]*asset.ComputeTask{
+		{Key: "uuid", Status: asset.ComputeTaskStatus_STATUS_DONE},
+	}, nil)
 	dbal.On("GetComputeTaskChildren", "uuid").Return([]*asset.ComputeTask{
 		{Key: "child", Status: asset.ComputeTaskStatus_STATUS_WAITING},
 	}, nil)

--- a/server/standalone/dbal/computetask.go
+++ b/server/standalone/dbal/computetask.go
@@ -208,7 +208,7 @@ func (d *DBAL) GetComputeTask(key string) (*asset.ComputeTask, error) {
 	stmt := getStatementBuilder().
 		Select("key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
 			"logs_permission", "metadata", "algo_key").
-		From("expanded_compute_tasks").
+		From("compute_tasks").
 		Where(sq.Eq{"channel": d.channel, "key": key})
 
 	row, err := d.queryRow(stmt)
@@ -245,7 +245,7 @@ func (d *DBAL) GetComputeTaskChildren(key string) ([]*asset.ComputeTask, error) 
 	stmt := getStatementBuilder().
 		Select("key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
 			"logs_permission", "metadata", "algo_key").
-		From("expanded_compute_tasks t").
+		From("compute_tasks t").
 		Join("compute_task_parents p ON t.key = p.child_task_key").
 		Where(sq.Eq{"t.channel": d.channel, "p.parent_task_key": key}).
 		OrderByClause("p.position ASC")
@@ -346,7 +346,7 @@ func (d *DBAL) queryBaseComputeTasks(pagination *common.Pagination, filterer fun
 	stmt := getStatementBuilder().
 		Select("key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
 			"logs_permission", "metadata", "algo_key").
-		From("expanded_compute_tasks").
+		From("compute_tasks").
 		Where(sq.Eq{"channel": d.channel}).
 		OrderByClause("creation_date ASC, key")
 

--- a/server/standalone/dbal/computetask.go
+++ b/server/standalone/dbal/computetask.go
@@ -13,6 +13,7 @@ import (
 	"github.com/substra/orchestrator/lib/common"
 	orcerrors "github.com/substra/orchestrator/lib/errors"
 	"github.com/substra/orchestrator/lib/persistence"
+	"github.com/substra/orchestrator/lib/service"
 	"github.com/substra/orchestrator/utils"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -26,7 +27,6 @@ type sqlComputeTask struct {
 	AlgoKey        string
 	Owner          string
 	ComputePlanKey string
-	ParentTaskKeys []string
 	Rank           int32
 	Status         asset.ComputeTaskStatus
 	Worker         string
@@ -43,7 +43,6 @@ func (t *sqlComputeTask) toComputeTask() (*asset.ComputeTask, error) {
 	task.AlgoKey = t.AlgoKey
 	task.Owner = t.Owner
 	task.ComputePlanKey = t.ComputePlanKey
-	task.ParentTaskKeys = t.ParentTaskKeys
 	task.Rank = t.Rank
 	task.Status = t.Status
 	task.Worker = t.Worker
@@ -131,13 +130,14 @@ func getCopyableComputeTaskValues(channel string, task *asset.ComputeTask) ([]in
 func (d *DBAL) insertParentTasks(tasks ...*asset.ComputeTask) error {
 	parentRows := make([][]interface{}, 0)
 	for _, t := range tasks {
-		if t.ParentTaskKeys != nil {
+		parentTasks := service.GetParentTaskKeys(t.Inputs)
+		if parentTasks != nil {
 			childTask, err := uuid.Parse(t.GetKey())
 			if err != nil {
 				return err
 			}
 
-			for idx, parentTaskKey := range t.ParentTaskKeys {
+			for idx, parentTaskKey := range parentTasks {
 				parentTask, err := uuid.Parse(parentTaskKey)
 				if err != nil {
 					return err
@@ -207,7 +207,7 @@ func (d *DBAL) GetExistingComputeTaskKeys(keys []string) ([]string, error) {
 func (d *DBAL) GetComputeTask(key string) (*asset.ComputeTask, error) {
 	stmt := getStatementBuilder().
 		Select("key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
-			"logs_permission", "metadata", "algo_key", "parent_task_keys").
+			"logs_permission", "metadata", "algo_key").
 		From("expanded_compute_tasks").
 		Where(sq.Eq{"channel": d.channel, "key": key})
 
@@ -218,7 +218,7 @@ func (d *DBAL) GetComputeTask(key string) (*asset.ComputeTask, error) {
 
 	ct := new(sqlComputeTask)
 	err = row.Scan(&ct.Key, &ct.ComputePlanKey, &ct.Status, &ct.Category, &ct.Worker, &ct.Owner, &ct.Rank, &ct.CreationDate,
-		&ct.LogsPermission, &ct.Metadata, &ct.AlgoKey, &ct.ParentTaskKeys)
+		&ct.LogsPermission, &ct.Metadata, &ct.AlgoKey)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, orcerrors.NewNotFound("computetask", key)
@@ -244,7 +244,7 @@ func (d *DBAL) GetComputeTask(key string) (*asset.ComputeTask, error) {
 func (d *DBAL) GetComputeTaskChildren(key string) ([]*asset.ComputeTask, error) {
 	stmt := getStatementBuilder().
 		Select("key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
-			"logs_permission", "metadata", "algo_key", "parent_task_keys").
+			"logs_permission", "metadata", "algo_key").
 		From("expanded_compute_tasks t").
 		Join("compute_task_parents p ON t.key = p.child_task_key").
 		Where(sq.Eq{"t.channel": d.channel, "p.parent_task_key": key}).
@@ -262,7 +262,7 @@ func (d *DBAL) GetComputeTaskChildren(key string) ([]*asset.ComputeTask, error) 
 
 		err = rows.Scan(
 			&ct.Key, &ct.ComputePlanKey, &ct.Status, &ct.Category, &ct.Worker, &ct.Owner, &ct.Rank, &ct.CreationDate,
-			&ct.LogsPermission, &ct.Metadata, &ct.AlgoKey, &ct.ParentTaskKeys)
+			&ct.LogsPermission, &ct.Metadata, &ct.AlgoKey)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +345,7 @@ func (d *DBAL) CountComputeTaskRegisteredOutputs(key string) (persistence.Comput
 func (d *DBAL) queryBaseComputeTasks(pagination *common.Pagination, filterer func(sq.SelectBuilder) sq.SelectBuilder) ([]*asset.ComputeTask, common.PaginationToken, error) {
 	stmt := getStatementBuilder().
 		Select("key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
-			"logs_permission", "metadata", "algo_key", "parent_task_keys").
+			"logs_permission", "metadata", "algo_key").
 		From("expanded_compute_tasks").
 		Where(sq.Eq{"channel": d.channel}).
 		OrderByClause("creation_date ASC, key")
@@ -386,7 +386,7 @@ func (d *DBAL) queryBaseComputeTasks(pagination *common.Pagination, filterer fun
 
 		err = rows.Scan(
 			&ct.Key, &ct.ComputePlanKey, &ct.Status, &ct.Category, &ct.Worker, &ct.Owner, &ct.Rank, &ct.CreationDate,
-			&ct.LogsPermission, &ct.Metadata, &ct.AlgoKey, &ct.ParentTaskKeys)
+			&ct.LogsPermission, &ct.Metadata, &ct.AlgoKey)
 		if err != nil {
 			return nil, "", err
 		}

--- a/server/standalone/dbal/computetask_test.go
+++ b/server/standalone/dbal/computetask_test.go
@@ -131,7 +131,7 @@ func TestGetTasks(t *testing.T) {
 
 	keys := []string{"93733214-02b6-4d69-90a8-4e3518a63470", "32f7be0b-b432-41e5-8225-8c53580ccc58"}
 
-	mock.ExpectQuery(`SELECT .* FROM expanded_compute_tasks`).
+	mock.ExpectQuery(`SELECT .* FROM compute_tasks`).
 		WithArgs(testChannel, keys[0], keys[1]).
 		WillReturnRows(makeTaskRows(keys[0], keys[1]))
 
@@ -161,7 +161,7 @@ func TestGetNoTask(t *testing.T) {
 
 	mock.ExpectBegin()
 
-	mock.ExpectQuery(`SELECT .* FROM expanded_compute_tasks`).
+	mock.ExpectQuery(`SELECT .* FROM compute_tasks`).
 		WithArgs(testChannel, "uuid").
 		WillReturnError(pgx.ErrNoRows)
 
@@ -187,7 +187,7 @@ func TestQueryComputeTasks(t *testing.T) {
 
 	keys := []string{"93733214-02b6-4d69-90a8-4e3518a63470", "32f7be0b-b432-41e5-8225-8c53580ccc58"}
 
-	mock.ExpectQuery(`SELECT .* FROM expanded_compute_tasks`).
+	mock.ExpectQuery(`SELECT .* FROM compute_tasks`).
 		WithArgs(testChannel, "testWorker", asset.ComputeTaskStatus_STATUS_DONE.String()).
 		WillReturnRows(makeTaskRows(keys[0], keys[1]))
 
@@ -357,7 +357,7 @@ func TestQueryComputeTasksNilFilter(t *testing.T) {
 
 	keys := []string{"93733214-02b6-4d69-90a8-4e3518a63470", "32f7be0b-b432-41e5-8225-8c53580ccc58"}
 
-	mock.ExpectQuery(`SELECT .* FROM expanded_compute_tasks`).
+	mock.ExpectQuery(`SELECT .* FROM compute_tasks`).
 		WithArgs(testChannel).
 		WillReturnRows(makeTaskRows(keys[0], keys[1]))
 

--- a/server/standalone/dbal/computetask_test.go
+++ b/server/standalone/dbal/computetask_test.go
@@ -36,7 +36,6 @@ func TestToComputeTask(t *testing.T) {
 		AlgoKey:        algo.Key,
 		Owner:          "owner",
 		ComputePlanKey: "cp_key",
-		ParentTaskKeys: []string{},
 		Rank:           0,
 		Status:         asset.ComputeTaskStatus_STATUS_DOING,
 		Worker:         "worker",
@@ -55,7 +54,6 @@ func TestToComputeTask(t *testing.T) {
 	assert.Equal(t, ct.AlgoKey, res.AlgoKey)
 	assert.Equal(t, ct.Owner, res.Owner)
 	assert.Equal(t, ct.ComputePlanKey, res.ComputePlanKey)
-	assert.Equal(t, ct.ParentTaskKeys, res.ParentTaskKeys)
 	assert.Equal(t, ct.Rank, res.Rank)
 	assert.Equal(t, ct.Status, res.Status)
 	assert.Equal(t, ct.Worker, res.Worker)
@@ -66,11 +64,11 @@ func TestToComputeTask(t *testing.T) {
 
 func makeTaskRows(taskKeys ...string) *pgxmock.Rows {
 	res := pgxmock.NewRows([]string{"key", "compute_plan_key", "status", "category", "worker", "owner", "rank", "creation_date",
-		"logs_permission", "metadata", "algo_key", "parent_task_keys"})
+		"logs_permission", "metadata", "algo_key"})
 
 	for _, key := range taskKeys {
 		res = res.AddRow(key, "cp_key", "STATUS_WAITING", "TASK_TRAIN", "worker", "owner", int32(0), time.Unix(0, 100),
-			[]byte("{}"), map[string]string{}, "algo_key", []string{})
+			[]byte("{}"), map[string]string{}, "algo_key")
 	}
 
 	return res
@@ -223,7 +221,6 @@ func TestAddComputeTask(t *testing.T) {
 		ComputePlanKey: "b16dcd88-32ca-4971-89a7-734b4ad1d778",
 		Status:         asset.ComputeTaskStatus_STATUS_WAITING,
 		Worker:         "testOrg",
-		ParentTaskKeys: []string{"f7743332-17f5-4d20-9e29-55312a081c9d", "b09c3fbf-9f92-460b-a87c-37f7f3bd4c63"},
 		Inputs: []*asset.ComputeTaskInput{
 			{
 				Identifier: "opener",
@@ -280,7 +277,6 @@ func TestAddComputeTasks(t *testing.T) {
 			ComputePlanKey: "899e7403-7e23-4c95-bb3f-7eb9e6d86b04",
 			Status:         asset.ComputeTaskStatus_STATUS_WAITING,
 			Worker:         "testOrg",
-			ParentTaskKeys: []string{"46830c5b-5a42-4cd8-8c29-6b66cc1ef348", "46830c5b-5a42-4cd8-8c29-6b66cc1ef349"},
 			Inputs: []*asset.ComputeTaskInput{
 				{
 					Identifier: "opener",
@@ -307,7 +303,6 @@ func TestAddComputeTasks(t *testing.T) {
 			ComputePlanKey: "899e7403-7e23-4c95-bb3f-7eb9e6d86b04",
 			Status:         asset.ComputeTaskStatus_STATUS_WAITING,
 			Worker:         "testOrg",
-			ParentTaskKeys: []string{"8d9fc421-15a6-4c3d-9082-3337a5436e83"},
 			Inputs: []*asset.ComputeTaskInput{
 				{
 					Identifier: "model",

--- a/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
+++ b/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
@@ -1,4 +1,6 @@
-DROP VIEW IF EXISTS expanded_compute_tasks;
-UPDATE events
-SET asset = asset - 'parent_task_keys'
-WHERE asset_kind = 'ASSET_COMPUTE_TASK';
+SELECT execute($$
+    DROP VIEW IF EXISTS expanded_compute_tasks;
+    UPDATE events
+    SET asset = asset - 'parentTaskKeys'
+    WHERE asset_kind = 'ASSET_COMPUTE_TASK';
+$$) WHERE view_exists('public', 'expanded_compute_tasks');

--- a/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
+++ b/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
@@ -1,1 +1,6 @@
-DROP VIEW IF EXISTS expanded_compute_tasks;
+SELECT execute($$
+    DROP VIEW IF EXISTS expanded_compute_tasks;
+    UPDATE events
+    SET asset = asset #- 'parent_task_keys'
+    WHERE asset_kind = 'ASSET_COMPUTE_TASK';
+$$) WHERE view_exists('public', 'expanded_compute_tasks');

--- a/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
+++ b/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS expanded_compute_tasks;

--- a/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
+++ b/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
@@ -1,6 +1,4 @@
-SELECT execute($$
-    DROP VIEW IF EXISTS expanded_compute_tasks;
-    UPDATE events
-    SET asset = asset - 'parent_task_keys'
-    WHERE asset_kind = 'ASSET_COMPUTE_TASK';
-$$) WHERE view_exists('public', 'expanded_compute_tasks');
+DROP VIEW IF EXISTS expanded_compute_tasks;
+UPDATE events
+SET asset = asset - 'parent_task_keys'
+WHERE asset_kind = 'ASSET_COMPUTE_TASK';

--- a/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
+++ b/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
@@ -1,6 +1,6 @@
 SELECT execute($$
     DROP VIEW IF EXISTS expanded_compute_tasks;
     UPDATE events
-    SET asset = asset #- '{parent_task_keys}'
+    SET asset = asset - 'parent_task_keys'
     WHERE asset_kind = 'ASSET_COMPUTE_TASK';
 $$) WHERE view_exists('public', 'expanded_compute_tasks');

--- a/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
+++ b/server/standalone/migration/000052_remove-parent_task_key-in-compute-task.up.sql
@@ -1,6 +1,6 @@
 SELECT execute($$
     DROP VIEW IF EXISTS expanded_compute_tasks;
     UPDATE events
-    SET asset = asset #- 'parent_task_keys'
+    SET asset = asset #- '{parent_task_keys}'
     WHERE asset_kind = 'ASSET_COMPUTE_TASK';
 $$) WHERE view_exists('public', 'expanded_compute_tasks');


### PR DESCRIPTION
## Companion PR

- https://github.com/Substra/substra-backend/pull/554

## Description

- Remove `compute_task_parents`:
 - in `ComputeTask`
 - in gRPC communication
 - remove `expanded_compute_tasks`

## How has this been tested?

CI

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
