### PR TITLE
chore: add issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: Report bug or performance issue
+title: "BUG: "
+labels: [Bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: context
+    attributes:
+      label: What are you trying to do?
+      description: >
+        Please provide some context on what you are trying to achieve.
+      placeholder:
+    validations:
+      required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description (what is happening?)
+      description: >
+        Please provide a description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior (what should happen?)
+      description: >
+        Please describe or show a code example of the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Reproducible Example
+      description: >
+        If possible, provide a reproducible example.
+      render: python
+
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Operating system
+      description: >
+        Which operating system are you using? (Provide the version number)
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Python version
+      description: >
+        Which Python version are you using?
+      placeholder: >
+        python --version
+    validations:
+      required: true
+  - type: textarea
+    id: substra-version
+    attributes:
+      label: Installed Substra versions
+      description: >
+        Which version of `substrafl`/ `substra` / `substra-tools` are you using?
+        You can check if they are compatible in the [compatibility table](https://docs.substra.org/en/stable/additional/release.html#compatibility-table).
+      placeholder: >
+        pip freeze | grep substra
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies-version
+    attributes:
+      label: Installed versions of dependencies
+      description: >
+        Please provide versions of dependencies which might be relevant to your issue (eg. `helm` and `skaffold` version for a deployment issue, `numpy` and `pytorch` for an algorithmic issue).
+
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Stacktrace
+      description: >
+        Please copy-paste here any log and/or stacktrace that might be relevant. Remove confidential and personal information if necessary.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question
+    url: https://join.slack.com/t/substra-workspace/shared_invite/zt-1fqnk0nw6-xoPwuLJ8dAPXThfyldX8yA
+    about: Don't hesitate to join the Substra community on Slack to ask all your questions!
+  - name: User Documentation Improvement
+    url: https://github.com/Substra/substra-documentation/issues
+    about: For issues related to the User Documentation, please open an issue on the substra-documentation repository
+  - name: Feature request
+    url: https://github.com/Substra/substra/issues
+    about: We centralize feature requests in the substra repository, please open an issue there


### PR DESCRIPTION
Signed-off-by: SdgJlbl <sarah.diot-girard@owkin.com>

## Description
Add templates for issues on GitHub.

Include a bug report form, a link to the documentation for documentation improvements, a link to Substra Slack for questions, and the option to open a blank (non templated) issue for all other needs.

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
