### PR TITLE
Fix/orchestrator db schemas broken

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,7 @@
 name: SQL Documentation
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,7 +1,6 @@
 name: SQL Documentation
 
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOLANG_MIGRATE_VERSION: v4.15.2
-      TBLS_VERSION: v1.56.1
+      TBLS_VERSION: v1.64.0
       ORCHESTRATOR_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable
       TBLS_DIR: tbls_tmp
       DB_DIAGRAM_PATH: docs/schemas/standalone-database.svg


### PR DESCRIPTION
## Description

The SQL schemas creation [has been broken](https://github.com/Substra/orchestrator/actions/workflows/doc.yml) for some months, due to the following error:
```sh
pq: CASE types "char" and text cannot be matched
```

This is due to our version of `tbls` not supporting postgresql `15.x.x` (fixed [in this PR](https://github.com/k1LoW/tbls/issues/382), merged in [`tbls` `v.1.56.8`](https://github.com/k1LoW/tbls/commit/d90f7ab181f97abf46371f0048aa1e2e07cf9434))

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
