### PR TITLE
chore: update curl

### DIFF
--- a/docker/orchestrator-chaincode-init/dependencies.json
+++ b/docker/orchestrator-chaincode-init/dependencies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "curl",
-    "version": "8.1.0-r0"
+    "version": "8.1.0"
   },
   {
     "name": "bash",

--- a/docker/orchestrator-chaincode-init/dependencies.json
+++ b/docker/orchestrator-chaincode-init/dependencies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "curl",
-    "version": "8.1.0"
+    "version": "8.1.0-r1"
   },
   {
     "name": "bash",


### PR DESCRIPTION
## Description

Fix [this error](https://github.com/Substra/orchestrator/actions/runs/5026679333/jobs/9015245443) at build time:

```
#7 [3/4] RUN apk update && apk add --no-cache jq 	&& jq -r '.[] | "\(.name)=\(.version)"' /tmp/dependencies.json | xargs apk add --no-cache 	&& rm /tmp/dependencies.json
#7 1.078 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
#7 1.419 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
#7 1.735 v3.16.5-89-ga8200e94bd0 [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
#7 1.735 v3.16.5-81-gcb4f17bdf87 [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
#7 1.735 OK: 17040 distinct packages available
#7 1.775 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
#7 1.867 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
#7 2.090 (1/2) Installing oniguruma (6.9.8-r0)
#7 2.102 (2/2) Installing jq (1.6-r1)
#7 2.115 Executing busybox-1.35.0-r17.trigger
#7 2.136 OK: 7 MiB in 16 packages
#7 2.302 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
#7 2.395 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
#7 2.612 ERROR: unable to select packages:
#7 2.646   curl-8.1.0-r1:
#7 2.646     breaks: world[curl=8.1.0-r0]
```


## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
