### PR TITLE
chore: release 0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1](https://github.com/Substra/orchestrator/releases/tag/0.35.1) - 2023-06-27
+
+### Changed
+
+- Minor dependency updates. See commit history for more details.
+
+
 ## [0.35.0](https://github.com/Substra/orchestrator/releases/tag/0.35.0) - 2023-06-12
 
 ### Added

--- a/charts/orchestrator/CHANGELOG.md
+++ b/charts/orchestrator/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.2] - 2023-06-27
+
+### Changed
+
+- bump app version to `0.35.1`
+
 ## [7.5.1] - 2023-06-12
 
 ### Changed

--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 11.6.2
 digest: sha256:1b96efc47b5dbe28bf34bcb694697325f3d2755a39ce2f1c371b2c9de9fac9d3
-generated: "2022-08-16T09:59:11.210482+02:00"
+generated: "2023-06-26T14:58:21.384947+02:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -3,8 +3,8 @@ name: orchestrator
 description: substra orchestration
 
 type: application
-version: 7.5.1
-appVersion: 0.35.0
+version: 7.5.2
+appVersion: 0.35.1
 kubeVersion: ">= 1.19.0-0"
 icon: https://avatars.githubusercontent.com/u/84009910?s=400
 


### PR DESCRIPTION
## [0.35.1](https://github.com/Substra/orchestrator/releases/tag/0.35.1) - 2023-06-27

### Changed

- Minor dependency updates. See commit history for more details.