### PR TITLE
fix(kubernetes): update deprecated annotation to use spec.ingressClassName

### DIFF
--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -172,7 +172,7 @@ Here's a sample ingress configuration:
 ingress:
   enabled: true
   annotations:
-    kubernetes.io/ingress.class: nginx
+    spec.ingressClassName: nginx
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   hosts:
   - host: orchestrator.org-1.com

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -171,8 +171,8 @@ Here's a sample ingress configuration:
 ```yaml
 ingress:
   enabled: true
+  ingressClassName: nginx
   annotations:
-    spec.ingressClassName: nginx
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   hosts:
   - host: orchestrator.org-1.com

--- a/examples/values/orchestrator-org-1-distributed.yaml
+++ b/examples/values/orchestrator-org-1-distributed.yaml
@@ -43,9 +43,8 @@ postgresql:
 ingress:
   enabled: true
   hostname: "orchestrator.org-1.com"
-  annotations:
-    spec.ingressClassName: nginx
-
+  ingressClassName: nginx
+  
 channels:
   - name: mychannel
     organizations: [ MyOrg1MSP ] # single org required here

--- a/examples/values/orchestrator-org-1-distributed.yaml
+++ b/examples/values/orchestrator-org-1-distributed.yaml
@@ -44,7 +44,7 @@ ingress:
   enabled: true
   hostname: "orchestrator.org-1.com"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    spec.ingressClassName: nginx
 
 channels:
   - name: mychannel

--- a/examples/values/orchestrator-org-1.yaml
+++ b/examples/values/orchestrator-org-1.yaml
@@ -42,7 +42,7 @@ ingress:
   enabled: true
   hostname: "orchestrator.org-1.com"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    spec.ingressClassName: nginx
 
 channels:
   - name: mychannel

--- a/examples/values/orchestrator-org-1.yaml
+++ b/examples/values/orchestrator-org-1.yaml
@@ -41,8 +41,7 @@ postgresql:
 ingress:
   enabled: true
   hostname: "orchestrator.org-1.com"
-  annotations:
-    spec.ingressClassName: nginx
+  ingressClassName: nginx
 
 channels:
   - name: mychannel

--- a/examples/values/orchestrator-org-2-distributed.yaml
+++ b/examples/values/orchestrator-org-2-distributed.yaml
@@ -43,8 +43,7 @@ postgresql:
 ingress:
   enabled: true
   hostname: "orchestrator.org-2.com"
-  annotations:
-    spec.ingressClassName: nginx
+  ingressClassName: nginx
 
 channels:
   - name: mychannel

--- a/examples/values/orchestrator-org-2-distributed.yaml
+++ b/examples/values/orchestrator-org-2-distributed.yaml
@@ -44,7 +44,7 @@ ingress:
   enabled: true
   hostname: "orchestrator.org-2.com"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    spec.ingressClassName: nginx
 
 channels:
   - name: mychannel


### PR DESCRIPTION
## Description

Changes the Ingress Class Annotation with `IngressClass` resource [as Ingress class annotation is deprecated](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation)

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
