### PR TITLE
chore: release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0](https://github.com/Substra/orchestrator/releases/tag/0.36.0) - 2023-09-07
+
 ### Changed
 
 - Replace deprecated ioutil package with os ([#269](https://github.com/Substra/orchestrator/pull/269))
@@ -22,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Minor dependency updates. See commit history for more details.
-
 
 ## [0.35.0](https://github.com/Substra/orchestrator/releases/tag/0.35.0) - 2023-06-12
 

--- a/charts/orchestrator/CHANGELOG.md
+++ b/charts/orchestrator/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.4] - 2023-09-07
+
+### Changed
+
+- bump app version to `0.36.0`
+
 ## [7.5.3] - 2023-07-25
 
 ### Changed

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -3,8 +3,8 @@ name: orchestrator
 description: substra orchestration
 
 type: application
-version: 7.5.3
-appVersion: 0.35.2
+version: 7.5.4
+appVersion: 0.36.0
 kubeVersion: ">= 1.19.0-0"
 icon: https://avatars.githubusercontent.com/u/84009910?s=400
 


### PR DESCRIPTION
### Changed

- Replace deprecated ioutil package with os ([#269](https://github.com/Substra/orchestrator/pull/269))