### PR TITLE
chore(deps): bump curl to 8.3.0-r0

### DIFF
--- a/docker/orchestrator-chaincode-init/dependencies.json
+++ b/docker/orchestrator-chaincode-init/dependencies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "curl",
-    "version": "8.2.1-r0"
+    "version": "8.3.0-r0"
   },
   {
     "name": "bash",


### PR DESCRIPTION
## Description

Increment the cURL version on `orchestrator-chaincode-init` to `8.3.0-r0`


## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
