### PR TITLE
chore(docker/orchestrator-chaincode-init): curl 8.3.0-r0 -> 8.4.0-r0

### DIFF
--- a/docker/orchestrator-chaincode-init/dependencies.json
+++ b/docker/orchestrator-chaincode-init/dependencies.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "curl",
-    "version": "8.3.0-r0"
+    "version": "8.4.0-r0"
   },
   {
     "name": "bash",


### PR DESCRIPTION
## Description
See [build](https://github.com/Substra/orchestrator/actions/runs/6482399335/job/17601837680#step:10:205):
```
#7 2.592 ERROR: unable to select packages:
#7 2.641   curl-8.4.0-r0:
#7 2.641     breaks: world[curl=8.3.0-r0]
```
<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
