### PR TITLE
chore(.github/workflows): bump postgres image

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -16,7 +16,7 @@ jobs:
   e2e:
     services:
       postgres:
-        image: postgres:14.6
+        image: postgres:16.0
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
## Description

Recent dependency update (#[bd9c1ed](https://github.com/Substra/orchestrator/commit/bd9c1ed88c656a9700ef355b521a2121fc8f26c6)) should have bumped the `postgres` version in e2e tests (see [upgrading](https://artifacthub.io/packages/helm/bitnami/postgresql#to-13-0-0)):
```txt
This major version changes the default PostgreSQL image from 15.x to 16.x. 
```

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
