### PR TITLE
fix: new function have no image

### DIFF
--- a/e2e/client/client.go
+++ b/e2e/client/client.go
@@ -192,10 +192,6 @@ func (c *TestClient) RegisterFunction(o *FunctionOptions) *asset.Function {
 			Checksum:       "1d55e9c55fa7ad6b6a49ad79da897d58be7ce8b76f92ced4c20f361ba3a0af6e",
 			StorageAddress: "http://somewhere.local/function/" + uuid.NewString(),
 		},
-		Image: &asset.Addressable{
-			Checksum:       "1d55e9c55fa7ad6b6a49ad79da897d58be7ce8b76f92ced4c20f361ba3a0af6e",
-			StorageAddress: "http://somewhere.local/function/" + uuid.NewString(),
-		},
 		NewPermissions: &asset.NewPermissions{Public: true},
 		Inputs:         o.Inputs,
 		Outputs:        o.Outputs,

--- a/lib/asset/function.proto
+++ b/lib/asset/function.proto
@@ -69,7 +69,6 @@ message NewFunction {
   map<string, string> metadata = 17;
   map<string, FunctionInput> inputs = 18;
   map<string, FunctionOutput> outputs = 19;
-  Addressable image = 20;
 }
 
 message GetFunctionParam {

--- a/lib/service/function.go
+++ b/lib/service/function.go
@@ -150,13 +150,17 @@ func (s *FunctionService) UpdateFunction(a *asset.UpdateFunctionParam, requester
 		return orcerrors.NewPermissionDenied("requester does not own the function")
 	}
 
-	if len(a.Image.GetChecksum()) == 0 && function.Status == asset.FunctionStatus_FUNCTION_STATUS_READY {
-		return orcerrors.FromValidationError(asset.FunctionKind, errors.New("Image checksum should not be empty when function status is ready"))
-	}
-
 	// Update function name
 	function.Name = a.Name
-	function.Image = a.Image
+
+	// Update Image if given
+	if len(a.Image.GetChecksum()) != 0 {
+		function.Image = a.Image
+	}
+
+	if len(function.Image.GetChecksum()) == 0 && function.Status == asset.FunctionStatus_FUNCTION_STATUS_READY {
+		return orcerrors.FromValidationError(asset.FunctionKind, errors.New("Image checksum should not be empty when function status is ready"))
+	}
 
 	event := &asset.Event{
 		EventKind: asset.EventKind_EVENT_ASSET_UPDATED,

--- a/lib/service/function.go
+++ b/lib/service/function.go
@@ -150,7 +150,7 @@ func (s *FunctionService) UpdateFunction(a *asset.UpdateFunctionParam, requester
 		return orcerrors.NewPermissionDenied("requester does not own the function")
 	}
 
-	// Update function name
+	// Update function name. Name cannot be blank.
 	function.Name = a.Name
 
 	// Update Image if given

--- a/lib/service/function.go
+++ b/lib/service/function.go
@@ -76,7 +76,7 @@ func (s *FunctionService) RegisterFunction(a *asset.NewFunction, owner string) (
 		Inputs:       a.Inputs,
 		Outputs:      a.Outputs,
 		Status:       asset.FunctionStatus_FUNCTION_STATUS_WAITING,
-		Image:        a.Image,
+		Image:        &asset.Addressable{StorageAddress: "", Checksum: ""},
 	}
 
 	function.Permissions, err = s.GetPermissionService().CreatePermissions(owner, a.NewPermissions)

--- a/lib/service/function_test.go
+++ b/lib/service/function_test.go
@@ -38,8 +38,8 @@ func TestRegisterFunction(t *testing.T) {
 		Checksum:       "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
 	}
 	functionImage := &asset.Addressable{
-		StorageAddress: "ftp://127.0.0.1/test",
-		Checksum:       "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
+		StorageAddress: "",
+		Checksum:       "",
 	}
 	newPerms := &asset.NewPermissions{Public: true}
 

--- a/lib/service/function_test.go
+++ b/lib/service/function_test.go
@@ -239,7 +239,7 @@ func TestUpdateSingleExistingFunction(t *testing.T) {
 
 }
 
-func TestUpdateNamOnlySingleExistingFunction(t *testing.T) {
+func TestUpdateNameOnlySingleExistingFunction(t *testing.T) {
 	dbal := new(persistence.MockDBAL)
 	provider := newMockedProvider()
 	es := new(MockEventAPI)

--- a/lib/service/function_test.go
+++ b/lib/service/function_test.go
@@ -49,7 +49,6 @@ func TestRegisterFunction(t *testing.T) {
 		Archive:        functionAddress,
 		Description:    description,
 		NewPermissions: newPerms,
-		Image:          functionImage,
 	}
 
 	perms := &asset.Permissions{Process: &asset.Permission{Public: true}}

--- a/lib/service/function_test.go
+++ b/lib/service/function_test.go
@@ -238,3 +238,76 @@ func TestUpdateSingleExistingFunction(t *testing.T) {
 	}
 
 }
+
+func TestUpdateNamOnlySingleExistingFunction(t *testing.T) {
+	dbal := new(persistence.MockDBAL)
+	provider := newMockedProvider()
+	es := new(MockEventAPI)
+	provider.On("GetEventService").Return(es)
+	provider.On("GetFunctionDBAL").Return(dbal)
+	service := NewFunctionService(provider)
+
+	existingFunction := &asset.Function{
+		Key:   "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
+		Name:  "function name",
+		Owner: "owner",
+		Image: &asset.Addressable{StorageAddress: "test/storage/address", Checksum: "4c67ad88309a48b48bc4c2e2c1a87a83"},
+	}
+
+	// Not given image is equivalent to give Image: &asset.Addressable{StorageAddress: "", Checksum: ""}. Update an image with blank value will be ignored.
+	updateFunctionParam := &asset.UpdateFunctionParam{
+		Key:  "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
+		Name: "Updated function name",
+	}
+
+	storedFunction := &asset.Function{
+		Key:   "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
+		Name:  "Updated function name",
+		Owner: "owner",
+		Image: &asset.Addressable{StorageAddress: "test/storage/address", Checksum: "4c67ad88309a48b48bc4c2e2c1a87a83"},
+	}
+
+	e := &asset.Event{
+		EventKind: asset.EventKind_EVENT_ASSET_UPDATED,
+		AssetKind: asset.AssetKind_ASSET_FUNCTION,
+		AssetKey:  storedFunction.Key,
+		Asset:     &asset.Event_Function{Function: storedFunction},
+	}
+
+	cases := map[string]struct {
+		requester string
+		valid     bool
+	}{
+		"update successful": {
+			requester: "owner",
+			valid:     true,
+		},
+		"update rejected: requester is not owner": {
+			requester: "user",
+			valid:     false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dbal.On("GetFunction", existingFunction.GetKey()).Return(existingFunction, nil).Once()
+
+			if tc.valid {
+				dbal.On("UpdateFunction", storedFunction).Return(nil).Once()
+				es.On("RegisterEvents", e).Once().Return(nil)
+			}
+
+			err := service.UpdateFunction(updateFunctionParam, tc.requester)
+
+			if tc.valid {
+				assert.NoError(t, err, "Update of function should not fail")
+			} else {
+				assert.Error(t, err, "Update of function should fail")
+			}
+
+			dbal.AssertExpectations(t)
+			es.AssertExpectations(t)
+		})
+	}
+
+}

--- a/lib/service/function_test.go
+++ b/lib/service/function_test.go
@@ -178,17 +178,20 @@ func TestUpdateSingleExistingFunction(t *testing.T) {
 		Key:   "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
 		Name:  "function name",
 		Owner: "owner",
+		Image: &asset.Addressable{StorageAddress: "", Checksum: ""},
 	}
 
 	updateFunctionParam := &asset.UpdateFunctionParam{
-		Key:  "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
-		Name: "Updated function name",
+		Key:   "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
+		Name:  "Updated function name",
+		Image: &asset.Addressable{StorageAddress: "test/storage/address", Checksum: "4c67ad88309a48b48bc4c2e2c1a87a83"},
 	}
 
 	storedFunction := &asset.Function{
 		Key:   "4c67ad88-309a-48b4-8bc4-c2e2c1a87a83",
 		Name:  "Updated function name",
 		Owner: "owner",
+		Image: &asset.Addressable{StorageAddress: "test/storage/address", Checksum: "4c67ad88309a48b48bc4c2e2c1a87a83"},
 	}
 
 	e := &asset.Event{

--- a/lib/service/functionstate.go
+++ b/lib/service/functionstate.go
@@ -84,6 +84,7 @@ func (s *FunctionService) ApplyFunctionAction(key string, action asset.FunctionA
 	}
 
 	function, err := s.GetFunctionDBAL().GetFunction(key)
+
 	if err != nil {
 		return err
 	}

--- a/server/standalone/dbal/addressable.go
+++ b/server/standalone/dbal/addressable.go
@@ -14,6 +14,18 @@ func (d *DBAL) addAddressable(addressable *asset.Addressable) error {
 	return d.exec(stmt)
 }
 
+func (d *DBAL) getOrAddAddressable(addressable *asset.Addressable) error {
+	addressableExist, err := d.AddressableExists(addressable.StorageAddress)
+	if err != nil {
+		return err
+	}
+	if !addressableExist {
+		return d.addAddressable(addressable)
+	} else {
+		return nil
+	}
+}
+
 func (d *DBAL) AddressableExists(storageAddress string) (bool, error) {
 	stmt := getStatementBuilder().
 		Select("COUNT(storage_address)").

--- a/server/standalone/dbal/addressable.go
+++ b/server/standalone/dbal/addressable.go
@@ -21,9 +21,8 @@ func (d *DBAL) getOrAddAddressable(addressable *asset.Addressable) error {
 	}
 	if !addressableExist {
 		return d.addAddressable(addressable)
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (d *DBAL) AddressableExists(storageAddress string) (bool, error) {

--- a/server/standalone/dbal/function.go
+++ b/server/standalone/dbal/function.go
@@ -53,7 +53,7 @@ func (d *DBAL) AddFunction(function *asset.Function) error {
 		return err
 	}
 
-	err = d.addAddressable(function.Image)
+	err = d.getOrAddAddressable(function.Image)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

On top of https://github.com/Substra/orchestrator/pull/288.

We remove Image from NewFunction, and we create the Addressable Image with empty strings when we register the Function.
We create the `getOrAddAddressable` to avoid multiple creation of the empty Image Addressable.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
