### PR TITLE
chore: allow alpha charts publication

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -11,7 +11,14 @@ on:
       - main
     paths:
       - "charts/**"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      publish-alpha:
+        description: |
+          Publish alpha chart. Chart version must be X.Y.Z-alpha.N.
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   # Cancel previous workflows on branch push
@@ -24,3 +31,4 @@ jobs:
     secrets: inherit
     with:
       helm-repositories: '[{"name": "bitnami", "url": "https://charts.bitnami.com/bitnami"}]'
+      publish-alpha: ${{ inputs.publish-alpha == true }}


### PR DESCRIPTION
Companion:

- https://github.com/Substra/substra-backend/pull/881
- https://github.com/Substra/orchestrator/pull/405
- https://github.com/Substra/substra-frontend/pull/333

Example of working worklfow (with fake publish):

- https://github.com/Substra/substra-backend/actions/runs/8628929572