### PR TITLE
fix: check plan.IsTerminated on IsPlanRunning

### DIFF
--- a/changes/432.changed
+++ b/changes/432.changed
@@ -1,0 +1,1 @@
+Rename `ComputePlanDBAL().IsPlanRunning(key)` to `ComputePlanDBAL().ArePlanTaksRunning(key)`

--- a/changes/432.fixed
+++ b/changes/432.fixed
@@ -1,0 +1,1 @@
+`IsPlanRunning` checks if a cancel of failure date is set before checking the tasks status.

--- a/e2e/computeplan_test.go
+++ b/e2e/computeplan_test.go
@@ -703,10 +703,14 @@ func TestIsPlanRunning(t *testing.T) {
 	require.Nil(t, err)
 
 	resp = appClient.IsPlanRunning("cp2")
-	require.True(t, resp.IsRunning)
+	require.False(t, resp.IsRunning)
 
-	appClient.CancelTask("task-cp2")
+	appClient.RegisterComputePlan(client.DefaultComputePlanOptions().WithKeyRef("cp3"))
+	appClient.RegisterTasks(client.DefaultTrainTaskOptions().WithPlanRef("cp3").WithKeyRef("task-cp3"))
+	appClient.StartTask("task-cp3")
 
-	resp = appClient.IsPlanRunning("cp2")
+	appClient.CancelTask("task-cp3")
+
+	resp = appClient.IsPlanRunning("cp3")
 	require.False(t, resp.IsRunning)
 }

--- a/lib/persistence/computeplan_dbal.go
+++ b/lib/persistence/computeplan_dbal.go
@@ -15,7 +15,7 @@ type ComputePlanDBAL interface {
 	SetComputePlanName(plan *asset.ComputePlan, name string) error
 	CancelComputePlan(plan *asset.ComputePlan, cancelationDate time.Time) error
 	FailComputePlan(plan *asset.ComputePlan, failureDate time.Time) error
-	IsPlanRunning(key string) (bool, error)
+	ArePlanTasksRunning(key string) (bool, error)
 }
 
 type ComputePlanDBALProvider interface {

--- a/lib/service/computeplan.go
+++ b/lib/service/computeplan.go
@@ -190,5 +190,10 @@ func (s *ComputePlanService) computePlanExists(key string) (bool, error) {
 // IsPlanRunning indicates whether there are tasks belonging to the compute plan
 // being executed or waiting to be executed
 func (s *ComputePlanService) IsPlanRunning(key string) (bool, error) {
-	return s.GetComputePlanDBAL().IsPlanRunning(key)
+	plan, err := s.GetPlan(key)
+	if plan.IsTerminated() {
+		return true, err
+	} else {
+		return s.GetComputePlanDBAL().IsPlanRunning(key)
+	}
 }

--- a/lib/service/computeplan.go
+++ b/lib/service/computeplan.go
@@ -192,7 +192,7 @@ func (s *ComputePlanService) computePlanExists(key string) (bool, error) {
 func (s *ComputePlanService) IsPlanRunning(key string) (bool, error) {
 	plan, err := s.GetPlan(key)
 	if plan.IsTerminated() {
-		return true, err
+		return false, err
 	} else {
 		return s.GetComputePlanDBAL().IsPlanRunning(key)
 	}

--- a/lib/service/computeplan.go
+++ b/lib/service/computeplan.go
@@ -194,6 +194,6 @@ func (s *ComputePlanService) IsPlanRunning(key string) (bool, error) {
 	if plan.IsTerminated() {
 		return false, err
 	} else {
-		return s.GetComputePlanDBAL().IsPlanRunning(key)
+		return s.GetComputePlanDBAL().ArePlanTasksRunning(key)
 	}
 }

--- a/lib/service/computetaskstate.go
+++ b/lib/service/computetaskstate.go
@@ -135,19 +135,7 @@ func (s *ComputeTaskService) applyTaskAction(task *asset.ComputeTask, action ass
 	case asset.ComputeTaskAction_TASK_ACTION_FAILED:
 		transition = transitionFailed
 	case asset.ComputeTaskAction_TASK_ACTION_DONE:
-		if task.ComputePlanKey != "" {
-			plan, err := s.GetComputePlanService().GetPlan(task.ComputePlanKey)
-			if err != nil {
-				return err
-			}
-			if plan.IsTerminated() {
-				transition = transitionCanceled
-			} else {
-				transition = transitionDone
-			}
-		} else {
-			transition = transitionDone
-		}
+		transition = transitionDone
 	case asset.ComputeTaskAction_TASK_ACTION_BUILD_STARTED:
 		transition = transitionBuilding
 	case asset.ComputeTaskAction_TASK_ACTION_BUILD_FINISHED:

--- a/server/standalone/dbal/computeplan.go
+++ b/server/standalone/dbal/computeplan.go
@@ -173,7 +173,7 @@ func (d *DBAL) FailComputePlan(plan *asset.ComputePlan, failureDate time.Time) e
 	return d.updateComputePlan(plan.Key, "failure_date", failureDate)
 }
 
-func (d *DBAL) IsPlanRunning(key string) (bool, error) {
+func (d *DBAL) ArePlanTasksRunning(key string) (bool, error) {
 	stmt := getStatementBuilder().
 		Select("status",
 			"COUNT(status)").

--- a/server/standalone/dbal/computeplan_test.go
+++ b/server/standalone/dbal/computeplan_test.go
@@ -167,7 +167,7 @@ func TestIsPlanRunning(t *testing.T) {
 
 	dbal := &DBAL{ctx: context.TODO(), tx: tx, channel: testChannel}
 
-	isRunning, err := dbal.IsPlanRunning(cpKey)
+	isRunning, err := dbal.ArePlanTasksRunning(cpKey)
 	assert.NoError(t, err)
 	assert.True(t, isRunning)
 


### PR DESCRIPTION
## Description
 check is plan.terminated when calling IsPlanRunning instead of changing the status of the task, cause it does not change the behaviour of `IsPlanRunning` (checked before changing task status).
 
 This PR revert a part of https://github.com/Substra/orchestrator/pull/427 and closes FL-1593
